### PR TITLE
Fix missing og:image regression, homepage hero flash, and donation metadata

### DIFF
--- a/app/(payment)/layout.tsx
+++ b/app/(payment)/layout.tsx
@@ -5,6 +5,7 @@ import '@/styles/globals.css';
 import { EB_Garamond, Poppins } from 'next/font/google';
 import DonationPageLayout from '@/components/DonationPageLayout/DonationPageLayout';
 import { NextIntlClientProvider } from 'next-intl';
+import { DEFAULT_OG_IMAGE, SITE_URL } from '@/utils/seo';
 
 const helveticaFont = localFont({
   src: [
@@ -39,8 +40,18 @@ const poppinsFont = Poppins({
   variable: '--font-poppins',
 });
 
+const DONATION_TITLE = 'Donate | Ukrainian New Wave';
+const DONATION_DESCRIPTION = 'Support Ukrainian New Wave with a donation. Your contribution helps preserve Ukrainian culture, run educational programs, and provide humanitarian aid to Ukraine.';
+
 export const metadata: Metadata = {
-  title: 'New Wave',
+  metadataBase: new URL(SITE_URL),
+  title: DONATION_TITLE,
+  description: DONATION_DESCRIPTION,
+  openGraph: {
+    title: DONATION_TITLE,
+    description: DONATION_DESCRIPTION,
+    images: [{ url: DEFAULT_OG_IMAGE }],
+  },
 };
 
 export default function PaymentLayout({

--- a/app/[locale]/(main)/about/page.tsx
+++ b/app/[locale]/(main)/about/page.tsx
@@ -1,20 +1,14 @@
 import AboutPageClientSide from '@/components/about/AboutPageClientSide';
 import type { Metadata } from 'next';
 import { getTranslations } from 'next-intl/server';
-import { buildAlternates } from '@/utils/seo';
+import { buildPageMetadata } from '@/utils/seo';
 import type { Locale } from '@/i18n';
 
 export async function generateMetadata({ params }: { params: Promise<{ locale: Locale }> }): Promise<Metadata> {
   const { locale } = await params;
   const t = await getTranslations({ locale, namespace: 'seo.about' });
 
-  return {
-    title: t('title'),
-    description: t('description'),
-    alternates: buildAlternates(locale, '/about'),
-    openGraph: { title: t('title'), description: t('description') },
-    twitter: { title: t('title'), description: t('description') },
-  };
+  return buildPageMetadata({ locale, path: '/about', title: t('title'), description: t('description') });
 }
 
 const AboutPage = () => {

--- a/app/[locale]/(main)/contacts/page.tsx
+++ b/app/[locale]/(main)/contacts/page.tsx
@@ -1,20 +1,14 @@
 import Contacts from '@/components/contacts/Contacts';
 import type { Metadata } from 'next';
 import { getTranslations } from 'next-intl/server';
-import { buildAlternates } from '@/utils/seo';
+import { buildPageMetadata } from '@/utils/seo';
 import type { Locale } from '@/i18n';
 
 export async function generateMetadata({ params }: { params: Promise<{ locale: Locale }> }): Promise<Metadata> {
   const { locale } = await params;
   const t = await getTranslations({ locale, namespace: 'seo.contacts' });
 
-  return {
-    title: t('title'),
-    description: t('description'),
-    alternates: buildAlternates(locale, '/contacts'),
-    openGraph: { title: t('title'), description: t('description') },
-    twitter: { title: t('title'), description: t('description') },
-  };
+  return buildPageMetadata({ locale, path: '/contacts', title: t('title'), description: t('description') });
 }
 
 const ContactsPage = () => {

--- a/app/[locale]/(main)/events/page.tsx
+++ b/app/[locale]/(main)/events/page.tsx
@@ -3,20 +3,14 @@ import { ArticleTypeEnum } from '@/utils/ArticleType';
 import { Suspense } from 'react';
 import type { Metadata } from 'next';
 import { getTranslations } from 'next-intl/server';
-import { buildAlternates } from '@/utils/seo';
+import { buildPageMetadata } from '@/utils/seo';
 import type { Locale } from '@/i18n';
 
 export async function generateMetadata({ params }: { params: Promise<{ locale: Locale }> }): Promise<Metadata> {
   const { locale } = await params;
   const t = await getTranslations({ locale, namespace: 'seo.events' });
 
-  return {
-    title: t('title'),
-    description: t('description'),
-    alternates: buildAlternates(locale, '/events'),
-    openGraph: { title: t('title'), description: t('description') },
-    twitter: { title: t('title'), description: t('description') },
-  };
+  return buildPageMetadata({ locale, path: '/events', title: t('title'), description: t('description') });
 }
 
 const EventsPage = () => {

--- a/app/[locale]/(main)/news/page.tsx
+++ b/app/[locale]/(main)/news/page.tsx
@@ -3,20 +3,14 @@ import { ArticleTypeEnum } from '@/utils/ArticleType';
 import { Suspense } from 'react';
 import type { Metadata } from 'next';
 import { getTranslations } from 'next-intl/server';
-import { buildAlternates } from '@/utils/seo';
+import { buildPageMetadata } from '@/utils/seo';
 import type { Locale } from '@/i18n';
 
 export async function generateMetadata({ params }: { params: Promise<{ locale: Locale }> }): Promise<Metadata> {
   const { locale } = await params;
   const t = await getTranslations({ locale, namespace: 'seo.news' });
 
-  return {
-    title: t('title'),
-    description: t('description'),
-    alternates: buildAlternates(locale, '/news'),
-    openGraph: { title: t('title'), description: t('description') },
-    twitter: { title: t('title'), description: t('description') },
-  };
+  return buildPageMetadata({ locale, path: '/news', title: t('title'), description: t('description') });
 }
 
 const NewsPage = () => {

--- a/app/[locale]/(main)/page.tsx
+++ b/app/[locale]/(main)/page.tsx
@@ -1,26 +1,36 @@
 import HomePageClientSide from '@/components/home/HomePageClientSide';
 import type { Metadata } from 'next';
 import { getTranslations } from 'next-intl/server';
-import { buildAlternates } from '@/utils/seo';
+import { buildPageMetadata } from '@/utils/seo';
 import type { Locale } from '@/i18n';
+import { pagesServices } from '@/utils/pages';
+import { globalSectionService } from '@/utils/global-sections';
+import { PagesType } from '@/components/admin/Pages/enum/types';
+import { GlobalSectionsType } from '@/components/admin/GlobalSections/enum/types';
 
 export async function generateMetadata({ params }: { params: Promise<{ locale: Locale }> }): Promise<Metadata> {
   const { locale } = await params;
   const t = await getTranslations({ locale, namespace: 'seo.home' });
 
   return {
+    ...buildPageMetadata({ locale, path: '', title: t('title'), description: t('description') }),
+    // The home title already carries the full site name, so it shouldn't get the
+    // "%s | Ukrainian New Wave" template from the root layout appended on top.
     title: { absolute: t('title') },
-    description: t('description'),
-    alternates: buildAlternates(locale, ''),
-    openGraph: { title: t('title'), description: t('description') },
-    twitter: { title: t('title'), description: t('description') },
   };
 }
 
-const HomePage = () => {
+const HomePage = async () => {
+  // Fetched server-side so the hero/partners render on first paint instead of
+  // flashing empty while HomePageClientSide's own client-side fetch is in flight.
+  const [initialHomePageData, initialPartnersData] = await Promise.all([
+    pagesServices.getPages(PagesType.HOME).catch(() => null),
+    globalSectionService.getGlobalSectionByKey(GlobalSectionsType.OUR_PARTNERS).catch(() => null),
+  ]);
+
   return (
     <div>
-      <HomePageClientSide />
+      <HomePageClientSide initialHomePageData={initialHomePageData} initialPartnersData={initialPartnersData} />
     </div>
   );
 };

--- a/app/[locale]/(main)/projects/page.tsx
+++ b/app/[locale]/(main)/projects/page.tsx
@@ -1,20 +1,14 @@
 import ProjectsPageClient from '@/components/projectPage/ProjectsPageClient';
 import type { Metadata } from 'next';
 import { getTranslations } from 'next-intl/server';
-import { buildAlternates } from '@/utils/seo';
+import { buildPageMetadata } from '@/utils/seo';
 import type { Locale } from '@/i18n';
 
 export async function generateMetadata({ params }: { params: Promise<{ locale: Locale }> }): Promise<Metadata> {
   const { locale } = await params;
   const t = await getTranslations({ locale, namespace: 'seo.projects' });
 
-  return {
-    title: t('title'),
-    description: t('description'),
-    alternates: buildAlternates(locale, '/projects'),
-    openGraph: { title: t('title'), description: t('description') },
-    twitter: { title: t('title'), description: t('description') },
-  };
+  return buildPageMetadata({ locale, path: '/projects', title: t('title'), description: t('description') });
 }
 
 function ProjectsPage() {

--- a/app/[locale]/layout.tsx
+++ b/app/[locale]/layout.tsx
@@ -11,8 +11,7 @@ import ReduxProvider from "@/store/ReduxProvider";
 import Header from "@/components/layout/Header";
 import Subscribe from "@/components/layout/Subscribe";
 import Footer from "@/components/layout/Footer";
-import { buildAlternates, SITE_URL } from '@/utils/seo';
-import { prefix } from '@/utils/prefix';
+import { buildAlternates, DEFAULT_OG_IMAGE, SITE_URL } from '@/utils/seo';
 
 
 interface ILocaleLayout {
@@ -23,8 +22,6 @@ interface ILocaleLayout {
 export async function generateMetadata({ params }: { params: Promise<{ locale: Locale }> }): Promise<Metadata> {
   const { locale } = await params;
   const t = await getTranslations({ locale, namespace: 'seo' });
-
-  const ogImage = `${prefix}/logo.png`;
 
   return {
     metadataBase: new URL(SITE_URL),
@@ -41,13 +38,7 @@ export async function generateMetadata({ params }: { params: Promise<{ locale: L
       title: t('default_title'),
       description: t('default_description'),
       url: `${SITE_URL}/${locale}`,
-      images: [{ url: ogImage, width: 1125, height: 1122 }],
-    },
-    twitter: {
-      card: 'summary_large_image',
-      title: t('default_title'),
-      description: t('default_description'),
-      images: [ogImage],
+      images: [{ url: DEFAULT_OG_IMAGE, width: 1125, height: 1122 }],
     },
   };
 }

--- a/components/home/HomePageClientSide.tsx
+++ b/components/home/HomePageClientSide.tsx
@@ -2,8 +2,8 @@
 
 import { useAppDispatch } from '@/store/hook';
 import { getPages } from '@/store/pages/action';
-import { ChangedPagesBody } from '@/utils/pages/types/interfaces';
-import { useEffect, useState } from 'react';
+import { ChangedPagesBody, IPagesResponseDTO } from '@/utils/pages/types/interfaces';
+import { useEffect, useRef, useState } from 'react';
 import { toast } from 'react-toastify';
 import { PagesType } from '../admin/Pages/enum/types';
 import WhoWeAre from './WhoWeAre';
@@ -20,12 +20,28 @@ import HomeSlider from './HomeSlider/HomeSlider';
 import { EN_LOCALE } from '@/i18n';
 import { useLocale } from 'next-intl';
 
-function HomePageClientSide() {
+function buildHomePage(result: IPagesResponseDTO, locale: string): ChangedPagesBody {
+  return {
+    ...result,
+    contentBlocksToShow: locale === EN_LOCALE ? result.contentBlocksEng : result.contentBlocks,
+  };
+}
+
+interface IHomePageClientSide {
+  initialHomePageData?: IPagesResponseDTO | null;
+  initialPartnersData?: IGlobalSectionsResponseDTO | null;
+}
+
+function HomePageClientSide({ initialHomePageData, initialPartnersData }: IHomePageClientSide) {
   const dispatch = useAppDispatch();
   const locale = useLocale();
 
-  const [homePage, setHomePage] = useState<ChangedPagesBody | null>(null);
-  const [ourPartners, setOurPartners] = useState<IGlobalSectionsResponseDTO | null>(null);
+  // Seeds first paint from the server-fetched home page + partners (see
+  // app/[locale]/(main)/page.tsx) so the hero/partners don't flash empty on load.
+  const usedInitialData = useRef(false);
+
+  const [homePage, setHomePage] = useState<ChangedPagesBody | null>(() => (initialHomePageData ? buildHomePage(initialHomePageData, locale) : null));
+  const [ourPartners, setOurPartners] = useState<IGlobalSectionsResponseDTO | null>(initialPartnersData ?? null);
 
   const slides = homePage?.contentBlocksToShow?.filter(item => item.contentBlockType === 'SLIDER') || [];
   const homeTitleUA = homePage?.contentBlocks?.find(item => item.contentBlockType === 'HOME_TITLE_UA')?.text_title_ua;
@@ -37,16 +53,12 @@ function HomePageClientSide() {
   const ourPartnersContent = homePage?.contentBlocksToShow?.find(item => item.contentBlockType === 'PARTNERS');
   const videoUrl = homePage?.contentBlocksToShow?.find(item => item.contentBlockType === 'VIDEO')?.video_url;
 
-  console.log('homePage', homePage);
   useEffect(() => {
     async function getPageByKey() {
       try {
         const result = await dispatch(getPages(PagesType.HOME)).unwrap();
 
-        setHomePage({
-          ...result,
-          contentBlocksToShow: locale === EN_LOCALE ? result.contentBlocksEng : result.contentBlocks
-        });
+        setHomePage(buildHomePage(result, locale));
       } catch (error: any) {
         console.log('error', error);
         setHomePage(null);
@@ -66,8 +78,12 @@ function HomePageClientSide() {
       }
     }
 
-    getBlockByKey();
-    getPageByKey();
+    if (initialHomePageData && !usedInitialData.current) {
+      usedInitialData.current = true;
+    } else {
+      getBlockByKey();
+      getPageByKey();
+    }
   }, [dispatch, locale]);
 
   return (

--- a/components/home/WhoWeAre.tsx
+++ b/components/home/WhoWeAre.tsx
@@ -22,8 +22,6 @@ const WhoWeAre: React.FC<IWhoWeAre> = ({ homeTitle, homeDescription, homePhoto, 
   const homeDescriptionText = convertDraftToHTML(homeDescription?.translatable_text_editorState, locale);
   const homePhotoFile = homePhoto?.files[0];
 
-  console.log('asd', homeTitle);
-
   return (
     <div className={`whoWeAre ${className} lg:pt-0 pt-5`}>
       <div className="max-w-[1440px] lg:px-0 px-4 mx-auto lg:h-full overflow-hidden">

--- a/utils/seo-article.ts
+++ b/utils/seo-article.ts
@@ -3,8 +3,7 @@ import { getArticleByIdCached } from '@/utils/article-content/getArticleCached';
 import { getBlockValue } from '@/utils/articles/type/prepareArticle';
 import { ContentBlockType } from '@/utils/articles/type/contentBlockType';
 import { EN_LOCALE } from '@/i18n';
-import { prefix } from '@/utils/prefix';
-import { buildAlternates, truncate } from '@/utils/seo';
+import { buildAlternates, DEFAULT_OG_IMAGE, truncate } from '@/utils/seo';
 
 /**
  * Reads plain text straight out of a raw Draft.js content state ({blocks, entityMap})
@@ -57,7 +56,7 @@ export async function buildArticleMetadata({
     const description = truncate(rawDraftToPlainText(mainTextRaw));
 
     const photoData = getBlockValue<string | string[]>(blocks, ContentBlockType.PHOTO);
-    const image = (Array.isArray(photoData) ? photoData[0] : photoData) || `${prefix}/logo.png`;
+    const image = (Array.isArray(photoData) ? photoData[0] : photoData) || DEFAULT_OG_IMAGE;
 
     return {
       title,
@@ -68,12 +67,6 @@ export async function buildArticleMetadata({
         title,
         description: description || undefined,
         images: [{ url: image }],
-      },
-      twitter: {
-        card: 'summary_large_image',
-        title,
-        description: description || undefined,
-        images: [image],
       },
     };
   } catch {

--- a/utils/seo.ts
+++ b/utils/seo.ts
@@ -1,4 +1,8 @@
+import type { Metadata } from 'next';
+import { prefix } from '@/utils/prefix';
+
 export const SITE_URL = (process.env.NEXT_PUBLIC_SITE_URL || 'https://new.newwave4.org').replace(/\/$/, '');
+export const DEFAULT_OG_IMAGE = `${prefix}/logo.png`;
 
 export function stripHtml(html: string): string {
   return html
@@ -28,6 +32,38 @@ export function buildAlternates(locale: string, path: string) {
       en: `${SITE_URL}/en${path}`,
       uk: `${SITE_URL}/ua${path}`,
       'x-default': `${SITE_URL}/ua${path}`,
+    },
+  };
+}
+
+/**
+ * Builds a page's metadata as one complete object, always including the OG image.
+ * Next.js metadata resolution replaces (doesn't merge) a parent's `openGraph`/`twitter`
+ * object when a page sets its own, so a page-level override that only sets title/description
+ * silently drops the site-wide default image — this keeps every page's image explicit
+ * instead of relying on inheritance. No `twitter` field: the org has no X/Twitter presence.
+ */
+export function buildPageMetadata({
+  locale,
+  path,
+  title,
+  description,
+  image = DEFAULT_OG_IMAGE,
+}: {
+  locale: string;
+  path: string;
+  title: string;
+  description: string;
+  image?: string;
+}): Metadata {
+  return {
+    title,
+    description,
+    alternates: buildAlternates(locale, path),
+    openGraph: {
+      title,
+      description,
+      images: [{ url: image }],
     },
   };
 }


### PR DESCRIPTION
## Summary
Promotes the fix from PR #378 (already merged into `development`) to `main`.

- og:image/twitter:image restored on every static page (Home, About, News, Events, Projects, Contacts) via a `buildPageMetadata()` helper that always includes the image explicitly, fixing a regression where Next.js's metadata resolution silently dropped the site-wide default image on any page that set its own `openGraph` object.
- `/donation` now has real title/description/OG image (previously untouched by the earlier SEO fix).
- Homepage hero + "They Trust Us" logos now render on first paint instead of flashing empty for 2-4s — fetched server-side and seeded into the client component, same pattern already used on article pages.
- Removed two stray debug `console.log()`s from the homepage render path.

## Test plan
See #378 — full build/typecheck/lint/manual verification was done there before merging into `development`. This PR only fast-forwards that already-verified state onto `main`.