### PR TITLE
Fix checkmark icons appearing on nav/dropdown/pagination site-wide

### DIFF
--- a/styles/globals.css
+++ b/styles/globals.css
@@ -289,22 +289,32 @@ html {
 }
 
 
-ul li {
-  position: relative;
-  padding-left: 40px;
-}
-ul li:not(:last-child) {
-  margin-bottom: 15px;
-}
-ul li:before {
-  position: absolute;
-  left: 0;
-  top: 8px;
-  content: '';
-  display: block;
-  width: 32px;
-  height: 32px;
-  background: url('./check-Icon.svg') no-repeat;
+/*
+ * Default checkmark-bullet styling for plain content <ul> lists (e.g. rich-text
+ * body copy). Must stay in @layer base: Tailwind v4 cascade layers give ANY
+ * layered rule priority over unlayered CSS regardless of selector specificity,
+ * so left unlayered this silently wins over every `before:content-none` utility
+ * used elsewhere (nav menus, dropdowns, pagination) to suppress it — which is
+ * exactly what happened across the site until this was scoped back into a layer.
+ */
+@layer base {
+  ul li {
+    position: relative;
+    padding-left: 40px;
+  }
+  ul li:not(:last-child) {
+    margin-bottom: 15px;
+  }
+  ul li:before {
+    position: absolute;
+    left: 0;
+    top: 8px;
+    content: '';
+    display: block;
+    width: 32px;
+    height: 32px;
+    background: url('./check-Icon.svg') no-repeat;
+  }
 }
 ol {
   list-style: auto;


### PR DESCRIPTION
## Summary
Fixes a real, reproducible UI bug: a checkmark icon was rendering next to every nav link, "Projects" dropdown item, and pagination control site-wide.

**Root cause**: `styles/globals.css` has a global `ul li:before { ...; background: url('./check-Icon.svg') }` rule, intended to give admin-authored rich-text bulleted lists a checkmark-style bullet. This repo migrated to Tailwind CSS v4 (`2f2d9e2`), which uses native CSS cascade layers — under v4, any layered rule beats unlayered CSS regardless of selector specificity. This rule sat unlayered (outside both `@layer utilities` blocks in the file), so it started winning against every `before:content-none` Tailwind utility used throughout the app (`Header`, `Menu`'s Projects dropdown, `Pagination`, etc.) to suppress it on non-content list items — utilities that reliably won under Tailwind v3's plain specificity-based cascade. This was a pure side effect of the framework migration, not anyone's application code.

**Fix**: wrap the rule in `@layer base`, matching Tailwind v4's documented layer order (`base < components < utilities`), restoring the pre-migration behavior. The rule itself is untouched — this only changes what can override it, so legitimate bulleted content (admin rich-text lists) keeps its checkmark-bullet styling, while nav/dropdown/pagination correctly suppress it via their existing classes.

## Test plan
- [x] `tsc --noEmit`: same 61 pre-existing errors, zero new (CSS-only change)
- [x] `next build`: succeeds
- [x] Verified live in-browser: checkmark gone from header nav and the "Projects" dropdown, no other visual regressions
- [x] Confirmed via code search that no component currently relies on the unscoped global rule — the one component that legitimately wants checkmark-bullet styling (`components/shared/List.tsx`) already fully self-contains its own `before:` styling independent of this rule