### PR TITLE
Fix checkmark icons appearing on nav/dropdown/pagination site-wide

### DIFF
--- a/styles/globals.css
+++ b/styles/globals.css
@@ -289,22 +289,32 @@ html {
 }
 
 
-ul li {
-  position: relative;
-  padding-left: 40px;
-}
-ul li:not(:last-child) {
-  margin-bottom: 15px;
-}
-ul li:before {
-  position: absolute;
-  left: 0;
-  top: 8px;
-  content: '';
-  display: block;
-  width: 32px;
-  height: 32px;
-  background: url('./check-Icon.svg') no-repeat;
+/*
+ * Default checkmark-bullet styling for plain content <ul> lists (e.g. rich-text
+ * body copy). Must stay in @layer base: Tailwind v4 cascade layers give ANY
+ * layered rule priority over unlayered CSS regardless of selector specificity,
+ * so left unlayered this silently wins over every `before:content-none` utility
+ * used elsewhere (nav menus, dropdowns, pagination) to suppress it — which is
+ * exactly what happened across the site until this was scoped back into a layer.
+ */
+@layer base {
+  ul li {
+    position: relative;
+    padding-left: 40px;
+  }
+  ul li:not(:last-child) {
+    margin-bottom: 15px;
+  }
+  ul li:before {
+    position: absolute;
+    left: 0;
+    top: 8px;
+    content: '';
+    display: block;
+    width: 32px;
+    height: 32px;
+    background: url('./check-Icon.svg') no-repeat;
+  }
 }
 ol {
   list-style: auto;


### PR DESCRIPTION
## Summary
Promotes the fix from PR #399 (already merged into `development`) to `main`.

A global `ul li:before` rule in `styles/globals.css` (checkmark icon background, intended only for admin-authored rich-text bulleted content) was rendering on every `<li>` site-wide — nav links, the "Projects" dropdown, and pagination controls. Root cause: this repo's Tailwind CSS v4 migration introduced cascade layers, where layered rules always beat unlayered CSS regardless of specificity; this rule sat unlayered, so it started overriding every `before:content-none` utility used to suppress it elsewhere — a side effect of the framework migration, not any application code change. Fixed by wrapping the rule in `@layer base`, restoring the pre-migration cascade behavior.

## Test plan
See #399 — full build verification and live in-browser confirmation (checkmark gone from nav/dropdown, no regressions) was done there before merging into `development`. This PR only fast-forwards that already-verified state onto `main`.