### PR TITLE
fix: cap release.yml job timeouts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,6 +22,14 @@ jobs:
     name: release
     needs: quality-gates
     runs-on: ubuntu-latest
+    # semantic-release's success phase comments/labels every PR referenced in
+    # the released commit range. On the very first release (no prior tag),
+    # that can be the entire repo history -- ~400 PRs at roughly 1/sec here,
+    # several minutes of genuine, correct work with no visible progress
+    # between GitHub Actions' step-level status updates. Cap it generously
+    # rather than leaving GitHub's default (up to 6h) in place, so a truly
+    # hung run fails loudly instead of silently burning CI minutes forever.
+    timeout-minutes: 30
     permissions:
       contents: write
       issues: write
@@ -64,6 +72,7 @@ jobs:
     needs: release
     if: needs.release.outputs.new_release_published == 'true'
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     permissions:
       packages: write
     steps:
@@ -114,6 +123,7 @@ jobs:
     needs: release
     if: needs.release.outputs.new_release_published == 'true'
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     permissions:
       packages: write
     steps:


### PR DESCRIPTION
## Summary

Follow-up from the first live run of `release.yml` on `development` (produced `v1.0.0-dev.1`). semantic-release's success phase comments/labels every PR referenced in the released commit range — on this first release (no prior tag), that meant the entire repo history, ~400 PRs at roughly one API call per second. That's several minutes of genuine, correct work with zero visible progress at the GitHub Actions step-level, which is indistinguishable from a real hang from the outside — and got mistaken for one, so that first run was cancelled partway through (after the actual release — tag, changelog, version-bump commit — had already completed correctly; only the image/chart publish got cut off).

Adds `timeout-minutes` to `release` (30), `docker-publish` (20), and `helm-publish` (15) so a *genuinely* hung run fails loudly well before GitHub's 6-hour default, without cutting off this legitimate one-time cost. Future releases will only touch PRs merged since the *previous* release, so this won't recur at this scale.

## Test plan

- [x] YAML validated
- [ ] Merging this will itself trigger `release.yml` again on `development`, producing `v1.0.0-dev.2` — this is the intended validation: confirms `docker-publish`/`helm-publish` complete successfully end-to-end now that the timeout exists as a safety net (not because it's expected to be needed this time).

🤖 Generated with [Claude Code](https://claude.com/claude-code)