### PR TITLE
feat: publish a CI/status dashboard to GitHub Pages

### DIFF
--- a/.github/workflows/status-page.yml
+++ b/.github/workflows/status-page.yml
@@ -1,0 +1,148 @@
+name: Status Page
+
+# Builds and publishes the public CI/status dashboard to GitHub Pages
+# (https://newwave4org.github.io/NewWave4.org-frontend-new/). Self-contained
+# rather than stitched together from other workflows' artifacts: e2e.yml only
+# runs on PRs into main + nightly + manual, so there's no guarantee a fresh
+# E2E artifact exists for an arbitrary trigger SHA. Running its own
+# unit-test + E2E pass costs a few extra CI minutes but guarantees the page
+# always reflects one consistent, fresh check. See scripts/status-page/.
+on:
+  push:
+    branches: [main]
+  schedule:
+    - cron: '17 3 * * *' # nightly, offset from e2e.yml's 0 3 * * *
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-node@v7
+        with:
+          node-version-file: '.nvmrc'
+          cache: 'npm'
+
+      - run: npm ci
+
+      - name: Run unit tests with coverage
+        continue-on-error: true
+        run: npm run test:coverage
+
+      # Same Docker build/run/wait pattern as e2e.yml -- see that file for
+      # why Playwright's built-in webServer isn't used directly.
+      - name: Generate .env file
+        uses: ./.github/actions/generate-env
+        with:
+          paypal_client_id: ${{ secrets.NEXT_PUBLIC_PAYPAL_CLIENT_ID }}
+          stripe_publishable_keys: ${{ secrets.NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEYS }}
+          stripe_webhook_url: ${{ secrets.NEXT_PUBLIC_STRIPE_WEBHOOK_URL }}
+          newwave_api_url: ${{ secrets.NEXT_PUBLIC_NEWWAVE_API_URL }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Build app image for E2E
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          push: false
+          load: true
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          tags: newwave4-frontend-status:${{ github.sha }}
+
+      - name: Start app container
+        run: docker run -d --name status-app -p 3000:3000 newwave4-frontend-status:${{ github.sha }}
+
+      - name: Wait for app to become ready
+        run: |
+          for i in $(seq 1 30); do
+            if wget -q -O - --timeout=5 --tries=1 http://127.0.0.1:3000/robots.txt; then
+              echo "App is ready."
+              exit 0
+            fi
+            sleep 2
+          done
+          echo "::error::App never became ready within 60s"
+          docker logs status-app
+          exit 1
+
+      - name: Install Playwright browsers
+        run: npx playwright install --with-deps chromium
+
+      - name: Run E2E tests
+        continue-on-error: true
+        run: npm run test:e2e
+        env:
+          E2E_BASE_URL: http://127.0.0.1:3000
+          E2E_ADMIN_EMAIL: ${{ secrets.E2E_ADMIN_EMAIL }}
+          E2E_ADMIN_PASSWORD: ${{ secrets.E2E_ADMIN_PASSWORD }}
+
+      - name: Dump app container logs
+        if: always()
+        run: docker logs status-app || true
+
+      - name: Stop app container
+        if: always()
+        run: docker rm -f status-app || true
+
+      - name: Fetch release info
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          mkdir -p .status-data
+          releases=$(gh api "repos/${{ github.repository }}/releases" --paginate)
+          stable=$(echo "$releases" | jq '[.[] | select(.prerelease == false)][0] // null | if . == null then null else {tag: .tag_name, name: .name, url: .html_url, publishedAt: .published_at} end')
+          prerelease=$(echo "$releases" | jq '[.[] | select(.prerelease == true)][0] // null | if . == null then null else {tag: .tag_name, name: .name, url: .html_url, publishedAt: .published_at} end')
+          jq -n --argjson stable "$stable" --argjson prerelease "$prerelease" '{stable: $stable, prerelease: $prerelease}' > .status-data/releases.json
+
+      - name: Check staging reachability
+        if: always()
+        run: |
+          mkdir -p .status-data
+          set +e
+          # new.newwave4.org, not staging.newwave4.org -- the latter is only
+          # helm/frontend-chart/values.yaml's committed *default* ingress
+          # host; the real staging deployment's actual host comes from the
+          # secret-sourced VALUES_YAML overlay in deploy-to-kubernetes.yml
+          # (confirmed via `kubectl -n staging get ingress`).
+          result=$(curl -s -o /dev/null -w '%{http_code} %{time_total}' --max-time 5 https://new.newwave4.org/robots.txt)
+          code=$(echo "$result" | cut -d' ' -f1)
+          time_s=$(echo "$result" | cut -d' ' -f2)
+          set -e
+          ok=false
+          if [ "$code" = "200" ]; then ok=true; fi
+          latency_ms=$(node -e "console.log(Math.round(parseFloat('${time_s:-0}') * 1000))")
+          checked_at=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+          jq -n --argjson ok $ok --arg httpCode "${code:-0}" --argjson latencyMs "$latency_ms" --arg checkedAt "$checked_at" \
+            '{ok: $ok, httpCode: ($httpCode | tonumber), latencyMs: $latencyMs, checkedAt: $checkedAt}' > .status-data/staging-health.json
+
+      - name: Generate status page
+        run: node scripts/status-page/generate.mjs
+
+      - uses: actions/upload-pages-artifact@v5
+        with:
+          path: status-site
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v5

--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,8 @@
 /coverage
 /test-results
 /playwright-report
+/.status-data
+/status-site
 
 # next.js
 /.next/

--- a/README.md
+++ b/README.md
@@ -3,8 +3,11 @@
 [![CI](https://github.com/NewWave4Org/NewWave4.org-frontend-new/actions/workflows/ci.yml/badge.svg)](https://github.com/NewWave4Org/NewWave4.org-frontend-new/actions/workflows/ci.yml)
 [![Release](https://github.com/NewWave4Org/NewWave4.org-frontend-new/actions/workflows/release.yml/badge.svg)](https://github.com/NewWave4Org/NewWave4.org-frontend-new/actions/workflows/release.yml)
 [![Latest release](https://img.shields.io/github/v/release/NewWave4Org/NewWave4.org-frontend-new)](https://github.com/NewWave4Org/NewWave4.org-frontend-new/releases)
+[![Status page](https://img.shields.io/badge/status_page-live-6ee7c9)](https://newwave4org.github.io/NewWave4.org-frontend-new/)
 
 Next.js 15 (App Router, React 19, TypeScript) frontend for [NewWave4.org](https://newwave4.org) — a public marketing/content site (news, events, programs, projects, donations) plus an internal admin panel for managing that content. Talks to a separate Java Spring Boot backend.
+
+**[View the live status dashboard →](https://newwave4org.github.io/NewWave4.org-frontend-new/)** — current release version, unit/E2E test results, coverage, and staging reachability, regenerated on every push to `main`.
 
 ## Quick start
 

--- a/docs/ci-cd.md
+++ b/docs/ci-cd.md
@@ -33,6 +33,7 @@ PRs into `main` are only accepted from a branch literally named `development` (`
 | `deploy-to-kubernetes.yml` | `workflow_dispatch` (manual) or `workflow_call` (from `release.yml`, staging only) | Helm-installs a specific chart/image version into a given namespace. Production is only ever reached via the manual `workflow_dispatch` path, and only accepts an exact `X.Y.Z` image tag. |
 | `e2e.yml` | PRs into `main`; nightly cron; manual | Playwright E2E against a full build. Not run on every push — slow, and hits the real staging API (`utils/http/axiosInstance.ts`'s hardcoded `baseURL`). |
 | `restrict-main-merges.yml` | PRs into `main` | Fails unless the PR's head branch is literally `development`. |
+| `status-page.yml` | push to `main`; nightly cron; manual | Self-contained (own unit-test + E2E run, not stitched from other workflows' artifacts) build that publishes a public status dashboard to GitHub Pages — release versions, unit/E2E test results, coverage, and staging reachability. See `scripts/status-page/`. |
 | `dependabot.yml` | n/a (config, not a workflow) | Weekly dependency PRs into `development` for `npm`, `docker`, and `github-actions` ecosystems. |
 
 ## Quality gates in detail

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -6,7 +6,9 @@ export default defineConfig({
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 2 : 0,
   workers: process.env.CI ? 2 : undefined,
-  reporter: process.env.CI ? [['github'], ['html', { open: 'never' }]] : 'list',
+  reporter: process.env.CI
+    ? [['github'], ['html', { open: 'never' }], ['json', { outputFile: 'playwright-report/results.json' }]]
+    : 'list',
   use: {
     baseURL: process.env.E2E_BASE_URL || 'http://localhost:3000',
     trace: 'on-first-retry',

--- a/scripts/status-page/generate.mjs
+++ b/scripts/status-page/generate.mjs
@@ -1,0 +1,41 @@
+#!/usr/bin/env node
+// Builds the static status dashboard published to GitHub Pages
+// (.github/workflows/status-page.yml). Reads only already-fetched JSON files
+// under .status-data/ plus the existing coverage/ and playwright-report/
+// artifacts -- this script itself makes no network calls, so it can be run
+// locally with no secrets (missing inputs just render an honest "not
+// available" section instead of crashing -- see docs comment in lib/data.mjs).
+import { existsSync, mkdirSync, rmSync, writeFileSync, cpSync } from 'node:fs';
+import { gatherData } from './lib/data.mjs';
+import { STYLE, renderIndex, renderUnitTests, renderE2ETests } from './lib/render.mjs';
+
+const OUT_DIR = 'status-site';
+
+function main() {
+  const data = gatherData();
+
+  rmSync(OUT_DIR, { recursive: true, force: true });
+  mkdirSync(OUT_DIR, { recursive: true });
+  mkdirSync(`${OUT_DIR}/assets`, { recursive: true });
+
+  writeFileSync(`${OUT_DIR}/index.html`, renderIndex(data));
+  writeFileSync(`${OUT_DIR}/unit-tests.html`, renderUnitTests(data));
+  writeFileSync(`${OUT_DIR}/e2e-tests.html`, renderE2ETests(data));
+  writeFileSync(`${OUT_DIR}/assets/style.css`, STYLE);
+  writeFileSync(`${OUT_DIR}/data.json`, JSON.stringify(data, null, 2));
+
+  if (existsSync('coverage')) {
+    cpSync('coverage', `${OUT_DIR}/coverage`, { recursive: true });
+  }
+  if (existsSync('playwright-report')) {
+    cpSync('playwright-report', `${OUT_DIR}/e2e-report`, { recursive: true });
+  }
+
+  console.log(`Status page generated at ./${OUT_DIR}/`);
+  console.log(`  Unit tests: ${data.unit ? `${data.unit.passed}/${data.unit.total}` : 'not available'}`);
+  console.log(`  E2E tests:  ${data.e2e ? `${data.e2e.passed}/${data.e2e.total}` : 'not available'}`);
+  console.log(`  Releases:   ${data.releases ? 'available' : 'not available'}`);
+  console.log(`  Staging:    ${data.staging ? (data.staging.ok ? 'reachable' : 'unreachable') : 'not checked'}`);
+}
+
+main();

--- a/scripts/status-page/lib/data.mjs
+++ b/scripts/status-page/lib/data.mjs
@@ -1,0 +1,160 @@
+import { readFileSync, existsSync } from 'node:fs';
+import { execFileSync } from 'node:child_process';
+
+function readJsonSafe(path) {
+  try {
+    return JSON.parse(readFileSync(path, 'utf8'));
+  } catch {
+    return null;
+  }
+}
+
+function gitFallback(args, fallback = '') {
+  try {
+    return execFileSync('git', args, { encoding: 'utf8' }).trim();
+  } catch {
+    return fallback;
+  }
+}
+
+function repositoryFromRemote() {
+  const remote = gitFallback(['remote', 'get-url', 'origin']).replace(/\.git$/, '');
+  // Matches both git@github.com:org/repo and https://github.com/org/repo
+  // (repo names may themselves contain dots, e.g. NewWave4.org-frontend-new,
+  // so only the trailing .git suffix is stripped above, not dots in general).
+  const match = remote.match(/github\.com[:/](.+)$/);
+  return match ? match[1] : null;
+}
+
+function buildMeta() {
+  const sha = process.env.GITHUB_SHA || gitFallback(['rev-parse', 'HEAD']);
+  const refName = process.env.GITHUB_REF_NAME || gitFallback(['rev-parse', '--abbrev-ref', 'HEAD']);
+  const runId = process.env.GITHUB_RUN_ID || null;
+  const serverUrl = process.env.GITHUB_SERVER_URL || 'https://github.com';
+  const repository = process.env.GITHUB_REPOSITORY || repositoryFromRemote();
+  const runUrl = runId && repository ? `${serverUrl}/${repository}/actions/runs/${runId}` : null;
+  const commitUrl = repository && sha ? `${serverUrl}/${repository}/commit/${sha}` : null;
+  const commitMessage = gitFallback(['log', '-1', '--format=%s'], '');
+
+  return {
+    sha,
+    shortSha: sha ? sha.slice(0, 7) : 'unknown',
+    refName,
+    runUrl,
+    commitUrl,
+    commitMessage,
+    repository,
+    builtAt: new Date().toISOString(),
+  };
+}
+
+function buildUnitSummary() {
+  const raw = readJsonSafe('.status-data/vitest-results.json');
+  const cwd = process.cwd();
+  if (!raw) return null;
+
+  const files = (raw.testResults || []).map(file => ({
+    name: file.name.startsWith(cwd) ? file.name.slice(cwd.length + 1) : file.name,
+    status: file.status,
+    tests: (file.assertionResults || []).map(t => ({
+      title: t.title,
+      fullName: t.fullName,
+      status: t.status,
+      duration: t.duration ?? null,
+    })),
+  }));
+
+  return {
+    total: raw.numTotalTests ?? 0,
+    passed: raw.numPassedTests ?? 0,
+    failed: raw.numFailedTests ?? 0,
+    skipped: (raw.numPendingTests ?? 0) + (raw.numTodoTests ?? 0),
+    success: !!raw.success,
+    files,
+  };
+}
+
+function buildCoverageSummary() {
+  const raw = readJsonSafe('coverage/coverage-summary.json');
+  if (!raw || !raw.total) return null;
+  const { lines, statements, functions, branches } = raw.total;
+  return {
+    lines: lines?.pct ?? null,
+    statements: statements?.pct ?? null,
+    functions: functions?.pct ?? null,
+    branches: branches?.pct ?? null,
+  };
+}
+
+function buildE2ESummary() {
+  const raw = readJsonSafe('playwright-report/results.json');
+  if (!raw) return null;
+
+  const specs = [];
+
+  const collectSpecs = suite => {
+    for (const spec of suite.specs || []) {
+      specs.push({
+        file: suite.file || spec.file || 'unknown',
+        title: spec.title,
+        tests: (spec.tests || []).map(t => ({
+          status: t.status,
+          project: t.projectName,
+        })),
+      });
+    }
+    for (const child of suite.suites || []) collectSpecs(child);
+  };
+
+  for (const suite of raw.suites || []) collectSpecs(suite);
+
+  const stats = raw.stats || {};
+  return {
+    total: (stats.expected ?? 0) + (stats.unexpected ?? 0) + (stats.skipped ?? 0),
+    passed: stats.expected ?? 0,
+    failed: stats.unexpected ?? 0,
+    skipped: stats.skipped ?? 0,
+    flaky: stats.flaky ?? 0,
+    durationMs: stats.duration ?? null,
+    specs,
+  };
+}
+
+function buildReleases() {
+  return readJsonSafe('.status-data/releases.json');
+}
+
+function buildStagingHealth() {
+  return readJsonSafe('.status-data/staging-health.json');
+}
+
+function buildEnv() {
+  const pkg = readJsonSafe('package.json') || {};
+  let nvmrc = null;
+  try {
+    nvmrc = readFileSync('.nvmrc', 'utf8').trim();
+  } catch {
+    nvmrc = null;
+  }
+
+  return {
+    appVersion: pkg.version || 'unknown',
+    node: nvmrc,
+    next: pkg.dependencies?.next || null,
+    react: pkg.dependencies?.react || null,
+    playwright: pkg.devDependencies?.['@playwright/test'] || null,
+    vitest: pkg.devDependencies?.vitest || null,
+  };
+}
+
+export function gatherData() {
+  return {
+    meta: buildMeta(),
+    env: buildEnv(),
+    releases: buildReleases(),
+    staging: buildStagingHealth(),
+    unit: buildUnitSummary(),
+    coverage: buildCoverageSummary(),
+    e2e: buildE2ESummary(),
+  };
+}

--- a/scripts/status-page/lib/render.mjs
+++ b/scripts/status-page/lib/render.mjs
@@ -1,0 +1,483 @@
+export function escapeHtml(str) {
+  return String(str ?? '').replace(
+    /[&<>"']/g,
+    c => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' })[c],
+  );
+}
+
+function fmtPct(n) {
+  return typeof n === 'number' ? `${n.toFixed(1)}%` : '—';
+}
+
+function fmtDate(iso) {
+  if (!iso) return '—';
+  try {
+    return new Date(iso).toLocaleString('en-US', {
+      dateStyle: 'medium',
+      timeStyle: 'short',
+      timeZone: 'UTC',
+    }) + ' UTC';
+  } catch {
+    return iso;
+  }
+}
+
+function fmtMs(ms) {
+  if (typeof ms !== 'number') return '—';
+  if (ms < 1000) return `${Math.round(ms)}ms`;
+  return `${(ms / 1000).toFixed(1)}s`;
+}
+
+// status: 'pass' | 'fail' | 'warn' | 'neutral'
+export function pill(label, status = 'neutral') {
+  return `<span class="pill pill-${status}">${escapeHtml(label)}</span>`;
+}
+
+function unitOverallStatus(unit) {
+  if (!unit) return 'neutral';
+  if (unit.failed > 0) return 'fail';
+  return 'pass';
+}
+
+function e2eOverallStatus(e2e) {
+  if (!e2e) return 'neutral';
+  if (e2e.failed > 0) return 'fail';
+  if (e2e.flaky > 0) return 'warn';
+  return 'pass';
+}
+
+function stagingStatus(staging) {
+  if (!staging) return 'neutral';
+  return staging.ok ? 'pass' : 'fail';
+}
+
+export const STYLE = `
+:root {
+  color-scheme: dark;
+  --bg: #0b0e14;
+  --bg-elevated: #12161f;
+  --border: #232a38;
+  --text: #e6e9ef;
+  --text-dim: #8b94a7;
+  --accent: #6ee7c9;
+  --accent-strong: #34d399;
+  --pass: #34d399;
+  --pass-bg: rgba(52, 211, 153, 0.12);
+  --fail: #f87171;
+  --fail-bg: rgba(248, 113, 113, 0.12);
+  --warn: #fbbf24;
+  --warn-bg: rgba(251, 191, 36, 0.12);
+  --neutral: #9ca3af;
+  --neutral-bg: rgba(156, 163, 175, 0.12);
+}
+
+* { box-sizing: border-box; }
+
+body {
+  margin: 0;
+  background: radial-gradient(1200px 600px at 15% -10%, rgba(110, 231, 201, 0.08), transparent),
+              var(--bg);
+  color: var(--text);
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif;
+  line-height: 1.5;
+}
+
+.wrap {
+  max-width: 1080px;
+  margin: 0 auto;
+  padding: 0 24px 64px;
+}
+
+header.top {
+  padding: 40px 0 24px;
+  border-bottom: 1px solid var(--border);
+  margin-bottom: 32px;
+}
+
+header.top h1 {
+  font-size: 1.5rem;
+  margin: 0 0 4px;
+  letter-spacing: -0.02em;
+}
+
+header.top .tagline {
+  color: var(--text-dim);
+  font-size: 0.9rem;
+}
+
+nav.tabs {
+  display: flex;
+  gap: 4px;
+  margin-top: 20px;
+}
+
+nav.tabs a {
+  color: var(--text-dim);
+  text-decoration: none;
+  padding: 8px 14px;
+  border-radius: 8px;
+  font-size: 0.88rem;
+  font-weight: 500;
+  border: 1px solid transparent;
+}
+
+nav.tabs a:hover { color: var(--text); background: var(--bg-elevated); }
+nav.tabs a.active {
+  color: var(--accent);
+  background: var(--bg-elevated);
+  border-color: var(--border);
+}
+
+h2.section-title {
+  font-size: 0.78rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--text-dim);
+  margin: 40px 0 14px;
+}
+h2.section-title:first-of-type { margin-top: 0; }
+
+.card {
+  background: var(--bg-elevated);
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  padding: 20px;
+}
+
+.grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 16px;
+}
+
+.stat-card a { color: inherit; text-decoration: none; display: block; }
+.stat-card .label {
+  color: var(--text-dim);
+  font-size: 0.8rem;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  margin-bottom: 8px;
+}
+.stat-card .value {
+  font-size: 1.9rem;
+  font-weight: 600;
+  letter-spacing: -0.02em;
+}
+.stat-card .sub {
+  color: var(--text-dim);
+  font-size: 0.82rem;
+  margin-top: 6px;
+}
+.stat-card.linkable {
+  transition: border-color 0.15s, transform 0.15s;
+}
+.stat-card.linkable:hover {
+  border-color: var(--accent);
+  transform: translateY(-1px);
+}
+
+.pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 3px 10px;
+  border-radius: 999px;
+  font-size: 0.78rem;
+  font-weight: 600;
+}
+.pill-pass { color: var(--pass); background: var(--pass-bg); }
+.pill-fail { color: var(--fail); background: var(--fail-bg); }
+.pill-warn { color: var(--warn); background: var(--warn-bg); }
+.pill-neutral { color: var(--neutral); background: var(--neutral-bg); }
+
+.hero {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 20px;
+  flex-wrap: wrap;
+  margin-bottom: 32px;
+}
+.hero .headline {
+  font-size: 1.5rem;
+  font-weight: 600;
+  letter-spacing: -0.01em;
+}
+.hero .headline .pill { font-size: 1rem; padding: 4px 14px; }
+
+table.breakdown {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.88rem;
+}
+table.breakdown th {
+  text-align: left;
+  color: var(--text-dim);
+  font-weight: 500;
+  font-size: 0.76rem;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  padding: 10px 12px;
+  border-bottom: 1px solid var(--border);
+}
+table.breakdown td {
+  padding: 10px 12px;
+  border-bottom: 1px solid var(--border);
+  vertical-align: top;
+}
+table.breakdown tr:last-child td { border-bottom: none; }
+table.breakdown .file-row td { padding-top: 18px; font-weight: 600; color: var(--text); }
+table.breakdown .test-row .title { color: var(--text-dim); padding-left: 20px; }
+table.breakdown .duration { color: var(--text-dim); font-variant-numeric: tabular-nums; white-space: nowrap; }
+
+code, .mono { font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; font-size: 0.85em; }
+
+a.inline-link { color: var(--accent); }
+
+.releases {
+  display: flex;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+.release-chip {
+  border: 1px solid var(--border);
+  background: var(--bg-elevated);
+  border-radius: 10px;
+  padding: 10px 16px;
+}
+.release-chip .channel { font-size: 0.72rem; text-transform: uppercase; color: var(--text-dim); letter-spacing: 0.06em; }
+.release-chip .tag { font-size: 1.1rem; font-weight: 700; }
+
+footer.meta {
+  margin-top: 48px;
+  padding-top: 20px;
+  border-top: 1px solid var(--border);
+  color: var(--text-dim);
+  font-size: 0.82rem;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px 20px;
+}
+
+.links-row { display: flex; flex-wrap: wrap; gap: 10px 24px; }
+
+.empty-note {
+  color: var(--text-dim);
+  font-size: 0.88rem;
+  font-style: italic;
+}
+`;
+
+export function layout({ title, active, body, meta }) {
+  const nav = [
+    ['index.html', 'Overview'],
+    ['unit-tests.html', 'Unit Tests'],
+    ['e2e-tests.html', 'E2E Tests'],
+  ]
+    .map(
+      ([href, label]) =>
+        `<a href="${href}" class="${active === href ? 'active' : ''}">${label}</a>`,
+    )
+    .join('');
+
+  return `<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>${escapeHtml(title)} — NewWave4 Status</title>
+<link rel="stylesheet" href="assets/style.css" />
+</head>
+<body>
+<div class="wrap">
+  <header class="top">
+    <h1>NewWave4.org — Frontend Status</h1>
+    <div class="tagline">Live build health, test results, and release info — regenerated on every push to <code>main</code>, nightly, and on demand.</div>
+    <nav class="tabs">${nav}</nav>
+  </header>
+  ${body}
+  <footer class="meta">
+    <span>Commit <a class="inline-link" href="${meta.commitUrl || '#'}"><code>${escapeHtml(meta.shortSha)}</code></a> on <code>${escapeHtml(meta.refName)}</code></span>
+    <span>Built ${escapeHtml(fmtDate(meta.builtAt))}</span>
+    ${meta.runUrl ? `<span><a class="inline-link" href="${meta.runUrl}">View workflow run →</a></span>` : ''}
+  </footer>
+</div>
+</body>
+</html>`;
+}
+
+export function renderIndex(data) {
+  const { meta, env, releases, staging, unit, coverage, e2e } = data;
+
+  const overallStatus =
+    unitOverallStatus(unit) === 'fail' || e2eOverallStatus(e2e) === 'fail' ? 'fail' : 'pass';
+  const overallLabel = overallStatus === 'fail' ? 'Checks failing' : 'All checks passing';
+
+  const releaseChips = releases
+    ? `<div class="releases">
+        ${
+          releases.stable
+            ? `<div class="release-chip"><div class="channel">Stable (main)</div><a class="inline-link tag" href="${releases.stable.url}">${escapeHtml(releases.stable.tag)}</a></div>`
+            : '<div class="release-chip"><div class="channel">Stable (main)</div><div class="tag">—</div></div>'
+        }
+        ${
+          releases.prerelease
+            ? `<div class="release-chip"><div class="channel">Prerelease (development)</div><a class="inline-link tag" href="${releases.prerelease.url}">${escapeHtml(releases.prerelease.tag)}</a></div>`
+            : '<div class="release-chip"><div class="channel">Prerelease (development)</div><div class="tag">—</div></div>'
+        }
+      </div>`
+    : '<p class="empty-note">Release info not available for this build.</p>';
+
+  const unitCard = unit
+    ? `<a href="unit-tests.html">
+        <div class="label">Unit Tests</div>
+        <div class="value">${unit.passed}/${unit.total}</div>
+        <div class="sub">${pill(unit.failed > 0 ? `${unit.failed} failing` : 'passing', unitOverallStatus(unit))}${unit.skipped ? ` · ${unit.skipped} skipped` : ''}</div>
+      </a>`
+    : `<div class="label">Unit Tests</div><div class="empty-note">Not available for this build.</div>`;
+
+  const coverageCard = coverage
+    ? `<div class="label">Coverage (lines)</div>
+       <div class="value">${fmtPct(coverage.lines)}</div>
+       <div class="sub">Statements ${fmtPct(coverage.statements)} · Functions ${fmtPct(coverage.functions)} · Branches ${fmtPct(coverage.branches)}</div>`
+    : `<div class="label">Coverage</div><div class="empty-note">Not available for this build.</div>`;
+
+  const e2eCard = e2e
+    ? `<a href="e2e-tests.html">
+        <div class="label">E2E Tests</div>
+        <div class="value">${e2e.passed}/${e2e.total}</div>
+        <div class="sub">${pill(e2e.failed > 0 ? `${e2e.failed} failing` : 'passing', e2eOverallStatus(e2e))}${e2e.skipped ? ` · ${e2e.skipped} skipped` : ''}</div>
+      </a>`
+    : `<div class="label">E2E Tests</div><div class="empty-note">Not available for this build.</div>`;
+
+  const stagingCard = staging
+    ? `<div class="label">Staging Reachability</div>
+       <div class="value">${pill(staging.ok ? 'Reachable' : 'Unreachable', stagingStatus(staging))}</div>
+       <div class="sub">HTTP ${staging.httpCode ?? '—'} in ${fmtMs(staging.latencyMs)} · checked ${fmtDate(staging.checkedAt)}</div>`
+    : `<div class="label">Staging Reachability</div><div class="empty-note">Not checked for this build.</div>`;
+
+  const envCard = `<div class="label">Environment</div>
+     <div class="value" style="font-size:1.1rem">v${escapeHtml(env.appVersion)}</div>
+     <div class="sub">Node ${escapeHtml(env.node || '—')} · Next ${escapeHtml((env.next || '').replace('^', '') || '—')} · React ${escapeHtml((env.react || '').replace('^', '') || '—')}</div>`;
+
+  const linksRow = meta.repository
+    ? `<div class="links-row">
+        <a class="inline-link" href="https://github.com/${meta.repository}#readme">README</a>
+        <a class="inline-link" href="https://github.com/${meta.repository}/blob/main/docs/testing.md">Testing philosophy</a>
+        <a class="inline-link" href="https://github.com/${meta.repository}/blob/main/docs/known-issues.md">Known issues</a>
+        <a class="inline-link" href="https://github.com/${meta.repository}/blob/main/docs/ci-cd.md">CI/CD pipeline</a>
+        <a class="inline-link" href="https://github.com/${meta.repository}/releases">All releases</a>
+      </div>`
+    : '<p class="empty-note">Repository info not available for this build.</p>';
+
+  const body = `
+  <div class="hero">
+    <div class="headline">${pill(overallLabel, overallStatus)}</div>
+  </div>
+
+  <h2 class="section-title">Releases</h2>
+  ${releaseChips}
+
+  <h2 class="section-title">Build health</h2>
+  <div class="grid">
+    <div class="card stat-card linkable">${unitCard}</div>
+    <div class="card stat-card">${coverageCard}</div>
+    <div class="card stat-card linkable">${e2eCard}</div>
+    <div class="card stat-card">${stagingCard}</div>
+    <div class="card stat-card">${envCard}</div>
+  </div>
+
+  <h2 class="section-title">More about this project</h2>
+  ${linksRow}
+  `;
+
+  return layout({ title: 'Overview', active: 'index.html', body, meta });
+}
+
+export function renderUnitTests(data) {
+  const { meta, unit, coverage } = data;
+
+  let body;
+  if (!unit) {
+    body = `<h2 class="section-title">Unit tests</h2><p class="empty-note">No unit test results were available for this build.</p>`;
+  } else {
+    const coverageLine = coverage
+      ? `<div class="sub" style="margin-bottom:24px">Coverage: ${fmtPct(coverage.lines)} lines · ${fmtPct(coverage.statements)} statements · ${fmtPct(coverage.functions)} functions · ${fmtPct(coverage.branches)} branches — <a class="inline-link" href="coverage/index.html">full interactive report →</a></div>`
+      : '';
+
+    const rows = unit.files
+      .map(file => {
+        const fileStatus = file.status === 'passed' ? 'pass' : file.status === 'failed' ? 'fail' : 'neutral';
+        const testRows = file.tests
+          .map(t => {
+            const s = t.status === 'passed' ? 'pass' : t.status === 'failed' ? 'fail' : 'neutral';
+            return `<tr class="test-row"><td></td><td class="title">${escapeHtml(t.title)}</td><td>${pill(t.status, s)}</td><td class="duration">${fmtMs(t.duration)}</td></tr>`;
+          })
+          .join('');
+        return `<tr class="file-row"><td colspan="2"><code>${escapeHtml(file.name)}</code></td><td>${pill(file.status, fileStatus)}</td><td></td></tr>${testRows}`;
+      })
+      .join('');
+
+    body = `
+    <div class="hero">
+      <div class="headline">${pill(`${unit.passed}/${unit.total} passing`, unitOverallStatus(unit))}</div>
+    </div>
+    ${coverageLine}
+    <div class="card">
+      <table class="breakdown">
+        <thead><tr><th colspan="2">Test file / case</th><th>Status</th><th>Duration</th></tr></thead>
+        <tbody>${rows}</tbody>
+      </table>
+    </div>`;
+  }
+
+  return layout({ title: 'Unit Tests', active: 'unit-tests.html', body, meta });
+}
+
+export function renderE2ETests(data) {
+  const { meta, e2e } = data;
+
+  let body;
+  if (!e2e) {
+    body = `<h2 class="section-title">E2E tests</h2><p class="empty-note">No E2E test results were available for this build.</p>`;
+  } else {
+    const bySpec = new Map();
+    for (const spec of e2e.specs) {
+      if (!bySpec.has(spec.file)) bySpec.set(spec.file, []);
+      bySpec.get(spec.file).push(spec);
+    }
+
+    const rows = [...bySpec.entries()]
+      .map(([file, specs]) => {
+        const specRows = specs
+          .map(spec => {
+            const test = spec.tests[0] || {};
+            const s = test.status === 'expected' ? 'pass' : test.status === 'unexpected' ? 'fail' : 'neutral';
+            const label = test.status === 'expected' ? 'passed' : test.status === 'unexpected' ? 'failed' : 'skipped';
+            return `<tr class="test-row"><td></td><td class="title">${escapeHtml(spec.title)}</td><td>${pill(label, s)}</td></tr>`;
+          })
+          .join('');
+        return `<tr class="file-row"><td colspan="2"><code>${escapeHtml(file)}</code></td><td></td></tr>${specRows}`;
+      })
+      .join('');
+
+    const skipNote = e2e.skipped
+      ? `<p class="empty-note">${e2e.skipped} test${e2e.skipped === 1 ? '' : 's'} skipped — credential-gated specs (E2E_ADMIN_EMAIL/E2E_ADMIN_PASSWORD) that only run with real staging credentials configured. See <a class="inline-link" href="https://github.com/${meta.repository}/blob/main/docs/testing.md">docs/testing.md</a>.</p>`
+      : '';
+
+    body = `
+    <div class="hero">
+      <div class="headline">${pill(`${e2e.passed}/${e2e.total} passing`, e2eOverallStatus(e2e))}</div>
+    </div>
+    <p class="sub" style="margin-bottom:24px">Ran in ${fmtMs(e2e.durationMs)} — <a class="inline-link" href="e2e-report/index.html">full interactive Playwright report →</a></p>
+    ${skipNote}
+    <div class="card">
+      <table class="breakdown">
+        <thead><tr><th colspan="2">Spec / case</th><th>Status</th></tr></thead>
+        <tbody>${rows}</tbody>
+      </table>
+    </div>`;
+  }
+
+  return layout({ title: 'E2E Tests', active: 'e2e-tests.html', body, meta });
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -16,8 +16,10 @@ export default defineConfig({
     exclude: ['node_modules', '.next', 'e2e'],
     coverage: {
       provider: 'v8',
-      reporter: ['text', 'lcov', 'html'],
+      reporter: ['text', 'lcov', 'html', 'json-summary'],
       reportsDirectory: './coverage',
     },
+    reporters: ['default', 'json'],
+    outputFile: { json: '.status-data/vitest-results.json' },
   },
 });


### PR DESCRIPTION
## Summary
- New self-contained `status-page.yml` workflow (push to `main`, nightly, manual) that runs its own unit-test + E2E pass, gathers release/staging/environment info, and publishes a small static dashboard to GitHub Pages.
- Three pages (Overview / Unit Tests / E2E Tests), all relative-linked (project Pages site, not a root domain), plus the full existing coverage and Playwright HTML reports embedded as subpaths.
- Replaces a stale, orphaned Pages deployment from 2025-09-21 that predates any current workflow.
- `vitest.config.ts`/`playwright.config.ts` get small additive reporter config (JSON output) -- doesn't change existing reporter output or any other workflow's behavior.
- Caught and fixed a real discrepancy along the way: `helm/frontend-chart/values.yaml`'s committed ingress host default is `staging.newwave4.org`, but the actual live staging deployment's real host (confirmed via `kubectl -n staging get ingress`) is `new.newwave4.org` -- the staging-reachability check uses the real one.

## Test plan
- [x] Verified locally end-to-end: real `npm run test:coverage` + `npm run test:e2e` runs feeding `scripts/status-page/generate.mjs`
- [x] Verified both the full-data and missing-data (local dry-run) rendering paths
- [x] Served `status-site/` locally, confirmed all three pages + both embedded full reports (200s), grepped for root-absolute links (none found)
- [x] Full Vitest suite still passes (43/43), typecheck baseline unchanged (36)
- [x] CI (quality-gates, e2e) must pass on this PR
- [ ] After merge: manually `workflow_dispatch` `status-page.yml` once to confirm the deployed Pages site works end-to-end (real GitHub Releases API + real staging curl), then click through both subpages and embedded reports at the live URL