### PR TITLE
fix: clear all 36 TypeScript errors and make typecheck a blocking gate (#453)

### DIFF
--- a/.github/workflows/_quality-gates.yml
+++ b/.github/workflows/_quality-gates.yml
@@ -43,11 +43,10 @@ jobs:
           node-version-file: '.nvmrc'
           cache: 'npm'
       - run: npm ci
-      # Non-blocking for now: running this for real (previously never run in CI)
-      # surfaced ~37 pre-existing type errors already on development, unrelated
-      # to any single PR. See docs/known-issues.md. Flip to blocking once clean.
-      - name: Type check (non-blocking, see docs/known-issues.md)
-        continue-on-error: true
+      # Blocking since 2026-07-31: the 36-error backlog that forced
+      # continue-on-error is paid off (issue #453) and the tree is clean, so
+      # this is now the ratchet — any new type error fails the build.
+      - name: Type check
         run: npx tsc --noEmit
 
   lint:

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Open [http://localhost:3000](http://localhost:3000). For the full stack, includi
 | `npm run build` | Production build |
 | `npm run start` | Run a production build |
 | `npm run lint` | ESLint (currently non-blocking in CI — see [`docs/known-issues.md`](./docs/known-issues.md)) |
-| `npm run typecheck` | `tsc --noEmit` (currently non-blocking in CI — see [`docs/known-issues.md`](./docs/known-issues.md)) |
+| `npm run typecheck` | `tsc --noEmit` — **blocking** in CI, and `next build` validates types too |
 | `npm run test` | Vitest unit/component suite |
 | `npm run test:watch` | Vitest in watch mode |
 | `npm run test:coverage` | Vitest with coverage |
@@ -58,7 +58,7 @@ Every PR runs a quality-gate pipeline (casing guard, typecheck, lint, unit tests
 - Branch from `development`, name branches `feature/<description>` or `fix/<description>`.
 - Open PRs into `development`; PRs into `main` are only accepted from a branch literally named `development`.
 - PRs are **squash-merged**. Give your PR a [Conventional Commits](https://www.conventionalcommits.org/) title (`feat: ...`, `fix: ...`, `chore: ...`, etc.) — it's enforced by CI, and it becomes the commit that drives the next version bump and changelog entry. See [`docs/release-process.md`](./docs/release-process.md#writing-good-commitpr-title-messages).
-- Run `npm run typecheck`, `npm run test`, and `npm run lint` before opening a PR (CI runs all three, though `typecheck`/`lint` are non-blocking for now).
+- Run `npm run typecheck`, `npm run test`, and `npm run lint` before opening a PR. CI runs all three; `typecheck` and `test` are blocking, `lint` is not (TS7 incompatibility).
 
 ## Learn more
 

--- a/app/(admin)/admin/programs/page.tsx
+++ b/app/(admin)/admin/programs/page.tsx
@@ -60,7 +60,12 @@ function ProgramsPage() {
     setCurrentPage(page);
   }, []);
 
-  function handleSortChange(e: React.ChangeEvent<HTMLSpanElement>) {
+  // onClick, not onChange: a <span> never fires a change event. The click
+  // lands on the outer span while data-value sits on the inner up/down
+  // spans, so this reads e.target (what was actually clicked) rather than
+  // currentTarget. A click on neither arrow has no data-value and returns.
+  function handleSortChange(e: React.MouseEvent<HTMLSpanElement>) {
+    if (!(e.target instanceof HTMLElement)) return;
     const { value } = e.target.dataset;
 
     if (value === undefined) return;
@@ -69,7 +74,8 @@ function ProgramsPage() {
     setCurrentPage(0);
   }
 
-  function handleSortByDate(e: React.ChangeEvent<HTMLSpanElement>) {
+  function handleSortByDate(e: React.MouseEvent<HTMLSpanElement>) {
+    if (!(e.target instanceof HTMLElement)) return;
     const { value } = e.target.dataset;
 
     if (value === undefined) return;

--- a/app/(admin)/admin/projects/page.tsx
+++ b/app/(admin)/admin/projects/page.tsx
@@ -91,7 +91,12 @@ function ProgramsPage() {
     );
   };
 
-  function handleSortChange(e: React.ChangeEvent<HTMLSpanElement>) {
+  // onClick, not onChange: a <span> never fires a change event. The click
+  // lands on the outer span while data-value sits on the inner up/down
+  // spans, so this reads e.target (what was actually clicked) rather than
+  // currentTarget. A click on neither arrow has no data-value and returns.
+  function handleSortChange(e: React.MouseEvent<HTMLSpanElement>) {
+    if (!(e.target instanceof HTMLElement)) return;
     const { value } = e.target.dataset;
 
     if (value === undefined) return;
@@ -100,7 +105,8 @@ function ProgramsPage() {
     setCurrentPage(0);
   }
 
-  function handleSortByDate(e: React.ChangeEvent<HTMLSpanElement>) {
+  function handleSortByDate(e: React.MouseEvent<HTMLSpanElement>) {
+    if (!(e.target instanceof HTMLElement)) return;
     const { value } = e.target.dataset;
 
     if (value === undefined) return;

--- a/components/TextEditor/utils/convertDraftToHTML.tsx
+++ b/components/TextEditor/utils/convertDraftToHTML.tsx
@@ -1,4 +1,5 @@
 import { convertFromRaw, EditorState, ContentState } from 'draft-js';
+import type { ContentBlock, EntityInstance } from 'draft-js';
 import { stateToHTML } from 'draft-js-export-html';
 
 // Absolute destinations we are willing to emit into an href.
@@ -78,7 +79,7 @@ export function convertDraftToHTML(rawState: any, locale?: string): string {
       },
     },
 
-    blockStyleFn: block => {
+    blockStyleFn: (block: ContentBlock) => {
       const type = block.getType();
       switch (type) {
         case 'centerAlign':
@@ -94,7 +95,7 @@ export function convertDraftToHTML(rawState: any, locale?: string): string {
       }
     },
 
-    entityStyleFn: entity => {
+    entityStyleFn: (entity: EntityInstance) => {
       if (entity.getType() === 'LINK') {
         const href = resolveSafeHref(entity.getData()?.url, locale);
 

--- a/components/admin/Articles/ArticleContent.tsx
+++ b/components/admin/Articles/ArticleContent.tsx
@@ -3,6 +3,7 @@ import Button from '@/components/shared/Button';
 import Input from '@/components/shared/Input';
 import TextEditor from '@/components/TextEditor/TextEditor';
 import { convertFromRaw, convertToRaw, EditorState } from 'draft-js';
+import type { RawDraftContentState } from 'draft-js';
 import {
   getAllArticle,
   getArticleById,
@@ -112,7 +113,7 @@ const ArticleContent = ({ articleId, articleType }: IArticleContent) => {
                 .test('not-empty', 'Text block 1 is required', value => {
                   if (!value) return false;
                   try {
-                    return convertFromRaw(value).hasText();
+                    return convertFromRaw(value as RawDraftContentState).hasText();
                   } catch {
                     return false;
                   }
@@ -173,7 +174,7 @@ const ArticleContent = ({ articleId, articleType }: IArticleContent) => {
 
         const formData = {
           ...data,
-          title: isEngDirection ? data.titleEng : data.title,
+          title: isEngDirection ? (data.titleEng ?? data.title) : data.title,
         };
 
         setArticle(formData);

--- a/components/admin/Articles/ArticlePreview.tsx
+++ b/components/admin/Articles/ArticlePreview.tsx
@@ -27,7 +27,7 @@ const ArticlePreview = ({ articleId }: IArticlePreview) => {
   const [slides, setSlides] = useState<Slide[]>([]);
   const [articleVideoUrl, setArticleVideoUrl] = useState<string | null>('');
 
-  const quoteText = article?.contentBlocks?.find(item => item.contentBlockType === 'QUOTE');
+  const quoteText = article?.contentBlocks?.find((item: { contentBlockType?: string }) => item.contentBlockType === 'QUOTE');
 
   useEffect(() => {
     if (!articleId) return;

--- a/components/admin/Articles/ArticlesTable.tsx
+++ b/components/admin/Articles/ArticlesTable.tsx
@@ -100,7 +100,12 @@ const ArticlesTable: FC<Props> = ({ renderPagination, articleType }) => {
     );
   };
 
-  function handleSortChange(e: React.ChangeEvent<HTMLSpanElement>) {
+  // onClick, not onChange: a <span> never fires a change event. The click
+  // lands on the outer span while data-value sits on the inner up/down
+  // spans, so this reads e.target (what was actually clicked) rather than
+  // currentTarget. A click on neither arrow has no data-value and returns.
+  function handleSortChange(e: React.MouseEvent<HTMLSpanElement>) {
+    if (!(e.target instanceof HTMLElement)) return;
     const { value } = e.target.dataset;
 
     if (value === undefined) return;
@@ -111,7 +116,8 @@ const ArticlesTable: FC<Props> = ({ renderPagination, articleType }) => {
     console.log('Fetching articles, sortByCreatedAtDescending:', chooseSortDateType);
   }
 
-  function handleSortByDate(e: React.ChangeEvent<HTMLSpanElement>) {
+  function handleSortByDate(e: React.MouseEvent<HTMLSpanElement>) {
+    if (!(e.target instanceof HTMLElement)) return;
     const { value } = e.target.dataset;
 
     if (value === undefined) return;

--- a/components/admin/Pages/AboutUsForm.tsx
+++ b/components/admin/Pages/AboutUsForm.tsx
@@ -98,7 +98,7 @@ function AboutUsForm() {
   ) => {
     setEditorStates(prev => ({ ...prev, [id]: newState }));
 
-    const index = values.contentBlocks.findIndex(block => block.id === id);
+    const index = values.contentBlocks.findIndex((block: { id?: string | number }) => block.id === id);
 
     if (index === -1) return;
 

--- a/components/admin/Pages/HomeForm.tsx
+++ b/components/admin/Pages/HomeForm.tsx
@@ -97,7 +97,7 @@ function HomeForm() {
   const handleEditorChange = (id: string, values: any, newState: EditorState, setFieldValue: any) => {
     setEditorStates(prev => ({ ...prev, [id]: newState }));
 
-    const index = values.contentBlocks.findIndex(block => block.id === id);
+    const index = values.contentBlocks.findIndex((block: { id?: string | number }) => block.id === id);
 
     if (index === -1) return;
 
@@ -306,7 +306,7 @@ function HomeForm() {
                               <ImageLoading
                                 classBlock="min-h-[300px]"
                                 isAttach={true}
-                                uploadedUrls={block.files?.filter(f => !deletedFiles.includes(f)) || []}
+                                uploadedUrls={block.files?.filter((f: string) => !deletedFiles.includes(f)) || []}
                                 onFilesChange={(files, deleted) => {
                                   setFieldValue(`contentBlocks.${realIndex}.files`, files);
                                   setDeletedFiles(prev => [...prev, ...(deleted || [])]);
@@ -401,7 +401,7 @@ function HomeForm() {
                             <ImageLoading
                               classBlock="min-h-[300px]"
                               isAttach={true}
-                              uploadedUrls={block.files?.filter(f => !deletedFiles.includes(f)) || []}
+                              uploadedUrls={block.files?.filter((f: string) => !deletedFiles.includes(f)) || []}
                               onFilesChange={(files, deleted) => {
                                 setFieldValue(`contentBlocks.${realIndex}.files`, files);
                                 setDeletedFiles(prev => [...prev, ...(deleted || [])]);

--- a/components/admin/ProgramsPage/ProgramContent/ProgramContent.tsx
+++ b/components/admin/ProgramsPage/ProgramContent/ProgramContent.tsx
@@ -262,7 +262,7 @@ function ProgramContent({ programId }: { programId: number }) {
 
         setProgram({ 
           ...result, 
-          title: isEngDirection ? result.titleEng : result.title,
+          title: isEngDirection ? (result.titleEng ?? result.title) : result.title,
           contentBlocks: mergedBlocks 
         });
       } catch (error) {

--- a/components/admin/ProgramsPage/ProgramsTable/ProgramsTable.tsx
+++ b/components/admin/ProgramsPage/ProgramsTable/ProgramsTable.tsx
@@ -34,9 +34,9 @@ interface IProjectsTableProps {
   handleDeleteProject: (project: GetArticleByIdResponseDTO) => void;
   handleArchivedProject: (project: GetArticleByIdResponseDTO) => void;
   sortStatusVal: boolean;
-  handleStatusSort: (e: React.ChangeEvent<HTMLSpanElement>) => void;
+  handleStatusSort: (e: React.MouseEvent<HTMLSpanElement>) => void;
   chooseSortDateType: boolean;
-  handleSortByDate: (e: React.ChangeEvent<HTMLSpanElement>) => void;
+  handleSortByDate: (e: React.MouseEvent<HTMLSpanElement>) => void;
 }
 
 function ProgramsTable({

--- a/components/admin/ProjectsPage/ProjectContent/ProjectContent.tsx
+++ b/components/admin/ProjectsPage/ProjectContent/ProjectContent.tsx
@@ -169,7 +169,7 @@ function ProjectContent({ projectId }: { projectId: number }) {
 
         setProject({
           ...result,
-          title: isEngDirection ? result.titleEng : result.title,
+          title: isEngDirection ? (result.titleEng ?? result.title) : result.title,
           contentBlocks: mergedBlocks,
         });
       } catch (error) {
@@ -294,7 +294,7 @@ function ProjectContent({ projectId }: { projectId: number }) {
     const content = newState.getCurrentContent();
     const raw = convertToRaw(content);
 
-    const index = values.contentBlocks.findIndex(block => block.id === id);
+    const index = values.contentBlocks.findIndex((block: { id?: string | number }) => block.id === id);
 
     if (index === -1) return;
 

--- a/components/admin/ProjectsPage/ProjectsTable.tsx
+++ b/components/admin/ProjectsPage/ProjectsTable.tsx
@@ -36,9 +36,9 @@ interface IProjectsTableProps {
   handleDeleteProject: (project: GetArticleByIdResponseDTO) => void;
   handleArchivedProject: (project: GetArticleByIdResponseDTO) => void;
   sortStatusVal: boolean;
-  handleStatusSort: (e: React.ChangeEvent<HTMLSpanElement>) => void;
+  handleStatusSort: (e: React.MouseEvent<HTMLSpanElement>) => void;
   chooseSortDateType: boolean;
-  handleSortByDate: (e: React.ChangeEvent<HTMLSpanElement>) => void;
+  handleSortByDate: (e: React.MouseEvent<HTMLSpanElement>) => void;
 }
 
 function ProjectsTable({

--- a/components/admin/UsersPage/UserRow.tsx
+++ b/components/admin/UsersPage/UserRow.tsx
@@ -135,6 +135,7 @@ function UserRow({
                   )}
                   items={[
                     {
+                      id: 1,
                       label: `${
                         isDisabled
                           ? `You can resend in ${Math.floor(
@@ -153,6 +154,7 @@ function UserRow({
                       },
                     },
                     {
+                      id: 2,
                       label: 'Edit',
                       onClick: () => handleEditUser(user),
                     },

--- a/components/admin/helperComponents/DatePicker/DatePicker.tsx
+++ b/components/admin/helperComponents/DatePicker/DatePicker.tsx
@@ -5,17 +5,22 @@ import { useContext, useMemo, useState } from 'react';
 import { DtPicker } from 'react-calendar-datetime-picker';
 import 'react-calendar-datetime-picker/style.css';
 
-export interface IPickerValue {
-  from?: {
-    year: number;
-    month: number;
-    day: number;
-  } | null;
-  to?: {
-    year: number;
-    month: number;
-    day: number;
-  } | null;
+interface IPickerDay {
+  year: number;
+  month: number;
+  day: number;
+}
+
+/**
+ * DtPicker carries two shapes through one value prop: pickerType="single" uses a
+ * bare {year, month, day} (what convertFromISO returns), pickerType="range" uses
+ * {from, to}. This only modelled the range half, so every single-type call site
+ * was a type error. Modelled as one all-optional shape rather than a union so
+ * the range consumers can still read .from/.to without narrowing first.
+ */
+export interface IPickerValue extends Partial<IPickerDay> {
+  from?: IPickerDay | null;
+  to?: IPickerDay | null;
 }
 
 interface IDatePicker {

--- a/components/home/HomeSlider/Arrows/Arrows.tsx
+++ b/components/home/HomeSlider/Arrows/Arrows.tsx
@@ -1,7 +1,8 @@
 import ArrowLeft4Icon from '@/components/icons/navigation/ArrowLeft4Icon';
 import ArrowRight4Icon from '@/components/icons/navigation/ArrowRight4Icon';
+import type { CustomArrowProps } from 'react-slick';
 
-export function SampleNextArrow(props) {
+export function SampleNextArrow(props: CustomArrowProps) {
   const { className, style, onClick } = props;
   return (
     <div
@@ -15,7 +16,7 @@ export function SampleNextArrow(props) {
   );
 }
 
-export function SamplePrevArrow(props) {
+export function SamplePrevArrow(props: CustomArrowProps) {
   const { className, style, onClick } = props;
   return (
     <div

--- a/components/home/programs/ProgramsSlider.tsx
+++ b/components/home/programs/ProgramsSlider.tsx
@@ -11,6 +11,15 @@ import { EN_LOCALE, useRouter } from '@/i18n';
 import { useLocale, useTranslations } from 'next-intl';
 import { useRouter as useRouterNext} from 'next/navigation';
 
+// The store holds articles as `any[]`, and every article DTO types
+// contentBlocks as `any[] | null`, so these callbacks have no contextual
+// type. Naming just the fields this slider reads beats three `any` params.
+interface ProgramContentBlock {
+  contentBlockType?: string;
+  files?: string[];
+  translatable_text_text?: string;
+}
+
 const ProgramsSlider = () => {
   const locale = useLocale();
   const t = useTranslations();
@@ -53,13 +62,13 @@ const ProgramsSlider = () => {
   const slidesData = useMemo(() => {
     return programs.map(program => ({
       id: program.id,
-      imgSrc: program?.contentBlocks?.find(b => b.contentBlockType === 'SECTION_WITH_PHOTO')?.files?.[0] || '',
+      imgSrc: program?.contentBlocks?.find((b: ProgramContentBlock) => b.contentBlockType === 'SECTION_WITH_PHOTO')?.files?.[0] || '',
       alt: locale === EN_LOCALE ? program.titleEng : program.title,
       link: `/program/${program.id}`,
       title: locale === EN_LOCALE ? program.titleEng : program.title,
       text: locale === EN_LOCALE
-        ? program?.contentBlocksEng?.find(b => b.contentBlockType === 'DESCRIPTION_PROGRAM')?.translatable_text_text || ''
-        : program?.contentBlocks?.find(b => b.contentBlockType === 'DESCRIPTION_PROGRAM')?.translatable_text_text || '',
+        ? program?.contentBlocksEng?.find((b: ProgramContentBlock) => b.contentBlockType === 'DESCRIPTION_PROGRAM')?.translatable_text_text || ''
+        : program?.contentBlocks?.find((b: ProgramContentBlock) => b.contentBlockType === 'DESCRIPTION_PROGRAM')?.translatable_text_text || '',
     }));
   }, [programs, locale]);
 

--- a/components/layout/admin/adminHeader/AdminHeader.tsx
+++ b/components/layout/admin/adminHeader/AdminHeader.tsx
@@ -50,7 +50,7 @@ const AdminHeader = () => {
                 items={[
                   // { label: 'Профіль', href: adminLink.PROFILE, isLink: true },
                   // { label: 'Налаштування', href: adminLink.SETTINGS, isLink: true },
-                  { label: 'Log out', href: '#', isLink: false, onClick: handleLogOut },
+                  { id: 1, label: 'Log out', href: '#', isLink: false, onClick: handleLogOut },
                 ]}
               />
             </div>

--- a/components/news/FilterNews.tsx
+++ b/components/news/FilterNews.tsx
@@ -8,7 +8,6 @@ import { ArticleTypeEnum } from '@/utils/ArticleType';
 import { useAppSelector } from '@/store/hook';
 import { EN_LOCALE } from '@/i18n';
 import DropDown from '../shared/DropDown';
-import FilterIcon from '../icons/symbolic/FilterIcon';
 import ArrowDown4Icon from '../icons/navigation/ArrowDown4Icon';
 
 interface Item {

--- a/components/payment/PaypalComponent.tsx
+++ b/components/payment/PaypalComponent.tsx
@@ -14,7 +14,11 @@ function PaypalComponent() {
           amount: {
             value: amount,
           },
-          description: paymentDetails.description
+          // `description` was never a field on IPaymentDetails and nothing ever
+          // set it, so every PayPal order was created with description:
+          // undefined. PaymentForm sets `purpose` (the human-readable label),
+          // which is what the Stripe path and donation/finish both send.
+          description: paymentDetails.purpose
         },
       ],
     });

--- a/components/shared/DropDown.tsx
+++ b/components/shared/DropDown.tsx
@@ -61,7 +61,7 @@ const DropDown = ({
       {isOpen && (
         <div className={`absolute z-10 mt-2 bg-white border rounded-xl shadow-lg max-h-60 overflow-auto animate-fadeIn ${classNameMenu}`}>
           {items?.map(item => (
-            <div key={item.label} className={classNameItem}>
+            <div key={item.id} className={classNameItem}>
               {renderItem
                 ? renderItem(item, closeDropDown) 
                 : item.isLink && item.href

--- a/components/ui/SlickSlider/Arrows/Arrows.tsx
+++ b/components/ui/SlickSlider/Arrows/Arrows.tsx
@@ -1,7 +1,8 @@
 import ArrowLeft4Icon from '@/components/icons/navigation/ArrowLeft4Icon';
 import ArrowRight4Icon from '@/components/icons/navigation/ArrowRight4Icon';
+import type { CustomArrowProps } from 'react-slick';
 
-export function SampleNextArrow(props) {
+export function SampleNextArrow(props: CustomArrowProps) {
   const { className, style, onClick } = props;
   return (
     <div
@@ -15,7 +16,7 @@ export function SampleNextArrow(props) {
   );
 }
 
-export function SamplePrevArrow(props) {
+export function SamplePrevArrow(props: CustomArrowProps) {
   const { className, style, onClick } = props;
   return (
     <div

--- a/docs/README.md
+++ b/docs/README.md
@@ -6,6 +6,6 @@
 - [Testing](./testing.md) — the Vitest/React Testing Library/Playwright setup, what's covered, and what's deliberately not (yet).
 - [Local development](./local-development.md) — running the frontend locally; see [`setup.md`](../setup.md) for the full stack including the backend.
 - [Known issues](./known-issues.md) — pre-existing gaps and inconsistencies that are documented but intentionally not fixed as part of the CI/CD work.
-- [Architecture decision records](./decisions/) — the reasoning behind the non-obvious choices in this setup (tooling picks, why lint/typecheck are non-blocking for now, etc).
+- [Architecture decision records](./decisions/) — the reasoning behind the non-obvious choices in this setup (tooling picks, why lint is still non-blocking, etc).
 
 For the codebase architecture itself (route structure, domain module pattern, state management), see [`CLAUDE.md`](../CLAUDE.md) at the repo root.

--- a/docs/ci-cd.md
+++ b/docs/ci-cd.md
@@ -42,7 +42,7 @@ PRs into `main` are only accepted from a branch literally named `development` (`
 All defined in `_quality-gates.yml` as parallel jobs:
 
 - **`casing-guard`** (blocking) — fails if `components/payment/PaypalComponent.tsx` is missing or mis-cased imports (`@/components/Payment/`, `PayPalComponent`) are found. This is a hard CI requirement independent of everything else in this doc — see `CLAUDE.md`.
-- **`typecheck`** (non-blocking for now) — `tsc --noEmit`. See [known-issues.md](./known-issues.md) and [ADR 0003](./decisions/0003-lint-non-blocking-pending-ts7-support.md).
+- **`typecheck`** (blocking) — `tsc --noEmit`. The pre-existing error backlog was cleared in issue #453; see [known-issues.md](./known-issues.md).
 - **`lint`** (non-blocking) — `eslint .`. Blocked upstream by a TypeScript 7 incompatibility.
 - **`unit-test`** (blocking) — `npm run test:coverage` (Vitest), coverage uploaded as a build artifact.
 - **`docker-smoke`** (blocking) — builds the Docker image (GHA-cached, not pushed) via the real Dockerfile — which also fully exercises `next build` — and smoke-tests it by curling the running container for a valid HTML response. There's deliberately no separate standalone `build` job; one was tried and removed after it crashed unreproducibly on GitHub's own infrastructure (never locally) — see `docs/known-issues.md`.

--- a/docs/decisions/0003-lint-non-blocking-pending-ts7-support.md
+++ b/docs/decisions/0003-lint-non-blocking-pending-ts7-support.md
@@ -2,11 +2,17 @@
 
 ## Status
 
-Accepted
+Partially superseded (2026-07-31) — the `typecheck` half no longer applies.
+
+**`typecheck` is now blocking.** The ~37 (later 36) pre-existing errors this ADR was built around were all fixed in issue #453, so the premise below — "a blocking gate would fail on every PR regardless of content" — no longer holds for `typecheck`. `continue-on-error` is gone from that step, and `typescript.ignoreBuildErrors` is gone from `next.config.ts`, so `next build` validates types too (verified with a deliberate error: the build now exits 1).
+
+This also resolves the "Add a ratchet" alternative below, though not the way it was framed. At zero errors a blocking `tsc --noEmit` *is* the ratchet, so no baseline file or comparison script was needed — the "more moving parts" cost that alternative was rejected for never had to be paid.
+
+**The `lint` half stands unchanged.** `npm run lint` still cannot run under TypeScript 7; that is an upstream blocker, and `lint-compat-check.yml` still polls monthly for a fix.
 
 ## Date
 
-2026-07-19
+2026-07-19 (typecheck decision revised 2026-07-31)
 
 ## Context
 
@@ -30,6 +36,9 @@ Both `lint` and `typecheck` run as **non-blocking** steps in `_quality-gates.yml
 - Rejected for this pass (by explicit choice when this was raised) — revisit if the team decides the lint gap outweighs staying current on TypeScript.
 
 ### Fix all ~37 pre-existing type errors before enabling `typecheck` as blocking
+
+> **Chosen in the end, on 2026-07-31 (issue #453).** Deferred here rather than rejected; the reasoning below still describes why it was not done in the same pass as building the gates. Several of the errors turned out to be masking real defects (a dead import of a module that does not exist, PayPal orders sent with `description: undefined`, a dropdown remounting every second because it was keyed by a live countdown label, articles blanking their title when they had no English translation), which argues the deferral cost something.
+
 
 - Pros: most thorough; gets to a genuinely enforced gate immediately.
 - Cons: real bug-fixing work across ~20 files of business logic not otherwise touched by this effort — meaningfully expands scope beyond "build the CI/CD pipeline," and each fix deserves its own review rather than being bundled into infra work.

--- a/docs/known-issues.md
+++ b/docs/known-issues.md
@@ -2,11 +2,15 @@
 
 Documented, not fixed, as part of the CI/CD/testing/release work — either out of scope for that effort, or a real behavior change that deserves its own reviewed PR rather than riding along here.
 
-## Pre-existing TypeScript errors (typecheck baseline)
+## Pre-existing TypeScript errors — fixed (2026-07-31)
 
-Running `tsc --noEmit` for real in CI (it was never run before — `next.config.ts` has `typescript.ignoreBuildErrors: true`, so `next build` never caught these) surfaced **37 pre-existing type errors** across ~20 files, as of 2026-07-19, unrelated to the CI/CD work itself (confirmed: identical error count with or without this branch's changes). Spread across admin forms (`ArticleContent.tsx`, `AboutUsForm.tsx`, `HomeForm.tsx`, `ProgramContent.tsx`, `ProjectContent.tsx`, `ProjectsTable.tsx`, `ProgramsTable.tsx`, `UserRow.tsx`, `AdminHeader.tsx`), `store/article-content/article-content_slice.ts` (missing `EVENTS` key in `Record<ArticleTypeEnum, IArticleByType>`), `utils/articles/type/mapper.ts`, a missing module (`components/news/icons/symbolic/FilterIcon`), and a few others.
+`tsc --noEmit` reported **36 errors across 21 files** and nothing caught them: `typecheck` was `continue-on-error: true`, and `next.config.ts` set `typescript.ignoreBuildErrors: true` so `next build` never validated types either.
 
-This is why `typecheck` runs **non-blocking** in `_quality-gates.yml` for now (`continue-on-error: true`) rather than as a hard gate — see [ADR 0003](./decisions/0003-lint-non-blocking-pending-ts7-support.md), which covers both `lint` and `typecheck`'s non-blocking status. **New PRs should not add to this count.** Flip the `typecheck` step back to blocking once it's paid down; re-run `npx tsc --noEmit 2>&1 | grep -c 'error TS'` to check the current count against this baseline.
+**Both are gone (issue #453).** The tree is at zero errors, `typecheck` is a blocking gate in `_quality-gates.yml`, and `ignoreBuildErrors` has been removed — verified by planting a deliberate type error and confirming `next build` exits 1 (it exited 0 before). The no-ratchet gap ADR 0003 flagged is closed by reaching zero: blocking `tsc --noEmit` *is* the ratchet, with no baseline file to maintain.
+
+Several of the 36 were real defects rather than type noise, and are worth knowing about since they had shipped: a dead import of a non-existent `FilterIcon` module (elided by SWC only because it was never referenced — the first use would have broken the build); PayPal orders created with `description: undefined`; `DropDown` keyed by a label that is a live countdown, remounting the item every second; and admin content pages blanking an article's title when it had no English translation. See the PR for the full list.
+
+What is *not* fixed: the same backend "article" concept is still described by four overlapping, mutually inconsistent interfaces (`GetArticleByIdResponseDTO`, `Article`, `IArticleBody`, `ArticleFull`). `ArticleFull` was realigned to what its mapper actually returns, but reconciling all four is a data-model refactor with no test coverage to protect it — deliberately left out of the type-error cleanup.
 
 ## `npm run lint` is broken under TypeScript 7
 

--- a/docs/local-development.md
+++ b/docs/local-development.md
@@ -44,7 +44,7 @@ npm run start           # run a production build
 ## Before you commit
 
 ```bash
-npm run typecheck       # tsc --noEmit — non-blocking in CI for now, but worth checking
+npm run typecheck       # tsc --noEmit — blocking in CI, and next build checks types too
 npm run lint             # currently non-blocking in CI (TS7/typescript-eslint incompatibility)
 npm run test              # Vitest unit/component suite
 npm run format:check     # Prettier

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -16,7 +16,7 @@ This repo had zero test tooling before this work — no Jest/Vitest/Playwright, 
 | `npm run test:watch`    | Vitest in watch mode.                                                                                                    |
 | `npm run test:coverage` | Runs with v8 coverage, output to `coverage/` (uploaded as a CI artifact).                                                |
 | `npm run test:e2e`      | Runs the Playwright suite (`e2e/`) — builds and starts the app first unless `E2E_BASE_URL` is set.                       |
-| `npm run typecheck`     | `tsc --noEmit` (non-blocking in CI for now — see [known-issues.md](./known-issues.md)).                                  |
+| `npm run typecheck`     | `tsc --noEmit` — blocking in CI since the error backlog was cleared (issue #453).                                        |
 
 ## What's covered, and why (priority order)
 

--- a/next.config.ts
+++ b/next.config.ts
@@ -15,7 +15,6 @@ const nextConfig: NextConfig = {
   trailingSlash: false,
   basePath: process.env.NEXT_PUBLIC_BASE_PATH || '',
   assetPrefix: process.env.NEXT_PUBLIC_BASE_PATH || '',
-  typescript: { ignoreBuildErrors: true },
   experimental: { useTypeScriptCli: true },
 };
 

--- a/store/article-content/article-content_slice.ts
+++ b/store/article-content/article-content_slice.ts
@@ -18,6 +18,9 @@ const initialState: IArticleContentSlice = {
     [ArticleTypeEnum.EVENT]: { items: [], totalPages: 0, status: 'idle' },
     [ArticleTypeEnum.PROGRAM]: { items: [], totalPages: 0, status: 'idle' },
     [ArticleTypeEnum.PROJECT]: { items: [], totalPages: 0, status: 'idle' },
+    // Only ever used as a URL slug (see DopBlockItem), never populated — but the
+    // Record type claims it, and indexing byType['EVENTS'] without it is a crash.
+    [ArticleTypeEnum.EVENTS]: { items: [], totalPages: 0, status: 'idle' },
   },
 };
 

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,7 +1,6 @@
 import type { Config } from 'tailwindcss';
 
 export default {
-  mode: 'jit',
   content: ['./pages/**/*.{js,ts,jsx,tsx,mdx}', './components/**/*.{js,ts,jsx,tsx,mdx}', './components/*.{js,ts,jsx,tsx,mdx}', './app/**/*.{js,ts,jsx,tsx,mdx}'],
   theme: {
     extend: {

--- a/utils/articles/type/interface.ts
+++ b/utils/articles/type/interface.ts
@@ -1,3 +1,5 @@
+import { GetArticleByIdResponseDTO } from '@/utils/article-content/type/interfaces';
+
 export interface Article {
   id: number;
   articleType: string;
@@ -58,12 +60,18 @@ export interface ArticleResponseDTO extends Article {
   contentBlocks: ContentBlock[];
 }
 
-export interface ArticleFull extends Article {
-  mainPhoto: string,
-  photoList: string[],
-  photoSlider: string[],
-  quote: string,
-  mainText: string,
-  textblock2: string,
-  video: string,
-}
+// What mapGetArticleByIdResponseToFull actually returns: the response DTO
+// spread whole, plus the blocks it flattens out of contentBlocks. It used to
+// extend `Article`, which claimed a required `authorId` the DTO does not carry
+// (commented out there) and omitted `contentBlocks`, which the spread does
+// carry — so the producer and both consumers each disagreed with the type.
+// news/Article.tsx was already patching around it with an intersection.
+export type ArticleFull = GetArticleByIdResponseDTO & {
+  mainPhoto: string;
+  photoList: string[];
+  photoSlider: string[];
+  quote: string;
+  mainText: string;
+  textblock2: string;
+  video: string;
+};

--- a/utils/http/type/interface.ts
+++ b/utils/http/type/interface.ts
@@ -1,10 +1,17 @@
 import { AxiosRequestConfig } from 'axios';
-import { ApiEndpoint } from '../enums/api-endpoint';
 import HttpMethod from '../enums/http-method';
 
 export type RequestOptions = {
   readonly method: HttpMethod;
-  readonly url: ApiEndpoint | string | ((id: string | number) => string);
+  // `ApiEndpoint` used to be part of this union, but its value type is a union
+  // of string literals AND builders with differing parameter types — (id: number)
+  // and (key: string). Narrowing with `typeof url === 'function'` then produced a
+  // union of those signatures, whose callable parameter is their intersection,
+  // `never`, so buildRequestConfig could not call it at all. Every ApiEndpoint
+  // string member is already covered by `string` here, and every call site
+  // invokes its builder itself and passes the resulting string
+  // (`url: ApiEndpoint.UPDATE_PAGES(id)`), so nothing relied on the union.
+  readonly url: string | ((id: string | number) => string);
   readonly accessToken?: string | null;
   readonly body?: unknown;
   readonly params?: Record<string, any>;


### PR DESCRIPTION
Closes #453.

The type system was effectively off. `typecheck` ran `continue-on-error: true`, and `next.config.ts` set `typescript.ignoreBuildErrors: true`, so neither CI nor `next build` ever failed on a type error. 36 had accumulated across 21 files.

**All 36 are fixed. `continue-on-error` is gone and `ignoreBuildErrors` is removed** — verified by planting a deliberate type error and confirming `next build` exits 1 where it previously exited 0.

## On the ratchet

The issue argued a ratchet was worth adding *before* fixing anything. Reaching zero makes one unnecessary: a blocking `tsc --noEmit` **is** the ratchet, with no baseline file or comparison script to maintain — so the "more moving parts" cost ADR 0003 rejected that alternative for never had to be paid. ADR 0003's status is amended rather than rewritten; its `lint` half still stands.

## These were real defects, not type noise

| What | Impact |
|---|---|
| `FilterNews.tsx` imported `FilterIcon` — **a module that does not exist** | Built only because SWC elides unused imports before resolution. The first use of it breaks the build. |
| `PaypalComponent` read `paymentDetails.description` — never a field on `IPaymentDetails`, never set anywhere | **Every PayPal order was created with `description: undefined`.** Now uses `purpose`, which is what the Stripe path and `donation/finish` both send. |
| `DropDown` keyed rows by `item.label` while requiring an unused `id` | UserRow's label is a live countdown, so the key changed **every second** and React remounted the item each tick. Now keyed by the `id` the type always required. |
| `ArticleContent`/`ProgramContent`/`ProjectContent` set `title` to `titleEng` with no fallback | Blanked the title for any article with no English translation. Falls back to the Ukrainian title, as `mapper.ts` already did. |
| The article-content slice's `initialState` omitted the `EVENTS` key its own `Record` type requires | Indexing `byType['EVENTS']` returned `undefined` and threw. |
| Six sort handlers typed `ChangeEvent` but wired to `onClick` | A `<span>` never fires a change event. Retyped to `MouseEvent`, preserving `e.target` semantics (the `data-value` lives on the inner arrows, so `currentTarget` would have broken sorting entirely). |
| `ArticleFull` claimed a required `authorId` its mapper does not produce, and omitted `contentBlocks` the mapper does | `news/Article.tsx` was already patching around it with an intersection. Realigned to what the mapper actually returns. |

The rest were mechanical: implicit-`any` params (typed via `CustomArrowProps` from `@types/react-slick` and `ContentBlock`/`EntityInstance` from `@types/draft-js` where real types existed), a `mode: 'jit'` Tailwind **v2** key in a v4 config, `IPickerValue` modelling only the range shape when `pickerType="single"` passes a bare `{year,month,day}`, and `RequestOptions.url` including `ApiEndpoint`, whose builders have differing parameter types — narrowing produced their intersection, `never`, so `buildRequestConfig` could not call it at all.

## Deliberately not fixed

The same backend "article" concept is described by **four overlapping, mutually inconsistent interfaces**: `GetArticleByIdResponseDTO`, `Article`, `IArticleBody`, `ArticleFull`. Typing the store's `items: any[]` properly surfaced three genuine mismatches between them (`publishedAt` nullability, a missing `authorId`, `titleEng` optionality). That is a data-model refactor with no test coverage to protect it and the wrong thing to bundle into a type-error cleanup — reverted and documented in `known-issues.md` instead. Worth its own issue.

## Verification

All run, not assumed:

- `npx tsc --noEmit` → **0 errors**, exit 0 (was 36)
- clean `rm -rf .next && npm run build` → exit 0, and Next reports `✓ useTypeScriptCli / Running TypeScript` rather than skipping validation
- planted `const x: number = "str"` → `next build` **exits 1**; removed again, back to 0
- 97 unit tests pass; all 14 E2E specs still resolve via `--list`

## Reviewer notes

- **Behaviour changes are intentional and listed above** — chiefly the PayPal `description` and the `DropDown` key. Both are fixes, but they do change what ships; worth a look if you disagree with either reading of intent.
- `docs/known-issues.md`, ADR 0003, `README.md`, `docs/ci-cd.md`, `docs/testing.md`, `docs/local-development.md` and `docs/README.md` are all updated — the old "non-blocking, ~37 errors" claim appeared in seven places.
- Formatting was left alone: `prettier --check` already fails on 894 files (#455), so reformatting touched files would have buried the diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)