### PR TITLE
fix: replace the yahoo contact address with info@newwave4.org

### DIFF
--- a/components/contacts/Contacts.tsx
+++ b/components/contacts/Contacts.tsx
@@ -24,8 +24,8 @@ const Contacts: React.FC = () => {
           <div className="flex flex-col gap-y-4 lg:mb-0 mb-4">
             <div className="inline-flex gap-x-2">
               <MessageIcon color="#006ABB" />
-              <Link href={'mailto:newwaveorg4@yahoo.com'} className="text-body text-status-link">
-                newwaveorg4@yahoo.com
+              <Link href={'mailto:info@newwave4.org'} className="text-body text-status-link">
+                info@newwave4.org
               </Link>
             </div>
             <div className="inline-flex gap-x-2">


### PR DESCRIPTION
The public contacts page listed `newwaveorg4@yahoo.com` as the organisation's contact address, next to the general "contact us" form.

## Which mailbox

Both `info@newwave4.org` and `admin@newwave4.org` exist. Went with **`info@`**: this is the address site visitors are invited to write to for general enquiries, which is exactly what `info@` is for.

`admin@newwave4.org` is this codebase's **admin-panel operator identity** — it's the login account used in `AuthGate.test.tsx` and `LogIn.test.tsx`. Publishing it on a public page would both misdirect general enquiries and advertise an account that signs into the admin panel.

## Scope

One occurrence, changed in both the `mailto:` href and the visible link text. Verified nothing else needed changing:

- no `yahoo` reference remains anywhere in the tree
- the i18n message catalogues (`i18n/messages/{en,ua}.json`) carry no email addresses, so the value was not translated

## Verification

- `tsc --noEmit` unchanged at `development`'s 36-error baseline — this adds none
- 97 unit tests pass

Note `components/contacts/Contacts.tsx` has no direct test coverage, so this rests on reading the file rather than on a test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)