### PR TITLE
fix: remove 66 console.log/info calls and add a guard that works (#457)

### DIFF
--- a/.github/workflows/_quality-gates.yml
+++ b/.github/workflows/_quality-gates.yml
@@ -33,6 +33,35 @@ jobs:
           fi
           exit $bad
 
+  no-console-log:
+    name: no-console-log
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v7
+
+      # eslint.config.mjs carries a matching no-console rule, but `npm run lint`
+      # cannot run at all under TypeScript 7 (issue #454), so that rule enforces
+      # nothing today. This grep does, and it is why 66 console.log calls could
+      # accumulate across 32 files unnoticed (issue #457) -- among them a
+      # plaintext password and donor PII written to the browser console.
+      #
+      # console.error/console.warn are deliberately allowed: they are real
+      # diagnostics. Only log/info are debug leftovers.
+      #
+      # scripts/ and e2e/ are excluded -- Node CLI tools and test harnesses
+      # where writing to stdout is the entire point.
+      - name: Guard against console.log/console.info in shipped code
+        run: |
+          set -e
+          if grep -RInE "console\.(log|info)\s*\(" \
+               --include=\*.{ts,tsx,js,jsx} \
+               app components utils store stores i18n middleware.ts; then
+            echo "::error::Found console.log/console.info in shipped code. Use console.error or console.warn for real diagnostics, or remove the call."
+            exit 1
+          fi
+          echo "No console.log/console.info found in shipped code."
+
   typecheck:
     name: typecheck
     runs-on: ubuntu-latest

--- a/app/(admin)/admin/archive/page.tsx
+++ b/app/(admin)/admin/archive/page.tsx
@@ -58,7 +58,6 @@ function ArchivePage() {
 
       try {
         const result = await dispatch(getAllArticle(params)).unwrap();
-        console.log('result', result);
         //setAllArchiveArticles(result?.content);
         setTotalPages(result.totalPages);
       } catch (err) {

--- a/app/(admin)/admin/pages/[page]/page.tsx
+++ b/app/(admin)/admin/pages/[page]/page.tsx
@@ -11,7 +11,6 @@ function PageEdit() {
   const { page } = useParams();
   const router = useRouter();
 
-  console.log('pages', page);
 
   return (
     <div>

--- a/app/(admin)/admin/programs/preview/page.tsx
+++ b/app/(admin)/admin/programs/preview/page.tsx
@@ -32,7 +32,7 @@ function ProgramPreviewPage() {
 
         setProgram(result);
       } catch (error) {
-        console.log('error', error);
+        console.error('error', error);
         toast.error('Failed to fetch project');
       } finally {
         setLoadingProgram(false);

--- a/app/(admin)/admin/projects/preview/page.tsx
+++ b/app/(admin)/admin/projects/preview/page.tsx
@@ -32,7 +32,7 @@ function PreviewPage() {
 
         setProject(result);
       } catch (error) {
-        console.log('error', error);
+        console.error('error', error);
         toast.error('Failed to fetch project');
       } finally {
         setLoadingProgect(false);

--- a/components/SubscribePage/SubscribeResult.tsx
+++ b/components/SubscribePage/SubscribeResult.tsx
@@ -22,7 +22,7 @@ function SubscribeResult({token}: {token: string | null}) {
         } catch (error: any) {
           setStatus('error');
           setErrorMessage(error?.original?.errors[0]);
-          console.log('fetchSubscribeResult', error);
+          console.error('fetchSubscribeResult', error);
         }
       }
     }

--- a/components/TextEditor/toolBar/Link/AddLink.tsx
+++ b/components/TextEditor/toolBar/Link/AddLink.tsx
@@ -7,19 +7,15 @@ export function addLink(
 ): EditorState {
   const contentState = editorState.getCurrentContent();
 
-  console.log('selection isCollapsed:', selection.isCollapsed());
-  console.log('selection start:', selection.getStartOffset(), 'end:', selection.getEndOffset());
 
   const contentWithEntity = contentState.createEntity('LINK', 'MUTABLE', { url });
   const entityKey = contentWithEntity.getLastCreatedEntityKey();
 
-   console.log('entityKey:', entityKey);
 
   const newContent = Modifier.applyEntity(contentWithEntity, selection, entityKey);
 
   const newState = EditorState.set(editorState, { currentContent: newContent });
 
-  console.log('raw after:', convertToRaw(newState.getCurrentContent()));
 
 
   return EditorState.set(editorState, { currentContent: newContent });

--- a/components/UnsubscribePage/UnsubscribeResult.tsx
+++ b/components/UnsubscribePage/UnsubscribeResult.tsx
@@ -22,7 +22,7 @@ function UnsubscribeResult({id}: {id: string}) {
         } catch (error: any) {
           setStatus('error');
           setErrorMessage(error?.original?.errors[0]);
-          console.log('fetchUnsubscribeResult', error);
+          console.error('fetchUnsubscribeResult', error);
         }
       }
     }

--- a/components/about/AboutPageClientSide.tsx
+++ b/components/about/AboutPageClientSide.tsx
@@ -46,12 +46,11 @@ function AboutPageClientSide() {
         });
       } catch (error: any) {
         if (error.original.errors[0].includes('with key') || error.original.errors[0].includes('find page')) {
-          console.log('Section does not exist yet → creating new one');
           setAboutPage(null);
           return;
         }
 
-        console.log('error', error);
+        console.error('error', error);
         setAboutPage(null);
         toast.error('Failed to fetch Home page');
       }
@@ -64,12 +63,11 @@ function AboutPageClientSide() {
         setOurPartners(result);
       } catch (error: any) {
         if (error.original.errors[0].includes('with key') || error.original.errors[0].includes('find page')) {
-          console.log('Section does not exist yet → creating new one');
           setOurPartners(null);
           return;
         }
 
-        console.log('error', error);
+        console.error('error', error);
         toast.error('Failed to fetch partners');
       }
     }
@@ -81,12 +79,11 @@ function AboutPageClientSide() {
         setOurTeam(result);
       } catch (error: any) {
         if (error.original.errors[0].includes('with key') || error.original.errors[0].includes('find page')) {
-          console.log('Section does not exist yet → creating new one');
           setOurTeam(null);
           return;
         }
 
-        console.log('error', error);
+        console.error('error', error);
         toast.error('Failed to fetch Our Team');
       }
     }

--- a/components/admin/Articles/ArticleForm.tsx
+++ b/components/admin/Articles/ArticleForm.tsx
@@ -83,7 +83,7 @@ const ArticleForm = ({ articleType }: ArticleFormProps) => {
         setProjects(mappedProjects);
       } catch (err) {
         toast.error('Failed to fetch projects');
-        console.log(err);
+        console.error(err);
       }
     };
 

--- a/components/admin/Articles/ArticlesTable.tsx
+++ b/components/admin/Articles/ArticlesTable.tsx
@@ -113,7 +113,6 @@ const ArticlesTable: FC<Props> = ({ renderPagination, articleType }) => {
     setChooseSortStatusType(value === 'true');
     setCurrentPage(0);
 
-    console.log('Fetching articles, sortByCreatedAtDescending:', chooseSortDateType);
   }
 
   function handleSortByDate(e: React.MouseEvent<HTMLSpanElement>) {

--- a/components/admin/GlobalSections/OurTeam.tsx
+++ b/components/admin/GlobalSections/OurTeam.tsx
@@ -78,12 +78,11 @@ function OurTeam() {
           setOurTeam(result);
         } catch (error: any) {
           if (error.original.errors[0].includes('with key') || error.original.errors[0].includes('find page')) {
-            console.log('Section does not exist yet → creating new one');
             setOurTeam(null);
             return;
           }
   
-          console.log('error', error);
+          console.error('error', error);
           toast.error('Failed to fetch partners');
         }
       }

--- a/components/admin/GlobalSections/PartnersForm.tsx
+++ b/components/admin/GlobalSections/PartnersForm.tsx
@@ -49,12 +49,11 @@ function PartnersForm() {
         setOurPartners(result);
       } catch (error: any) {
         if (error.original.errors[0].includes('with key') || error.original.errors[0].includes('find page')) {
-          console.log('Section does not exist yet → creating new one');
           setOurPartners(null);
           return;
         }
 
-        console.log('error', error);
+        console.error('error', error);
         toast.error('Failed to fetch partners');
       }
     }

--- a/components/admin/GlobalSections/SocialLinksForm.tsx
+++ b/components/admin/GlobalSections/SocialLinksForm.tsx
@@ -52,12 +52,11 @@ function SocialLinksForm() {
         setSocialLinks(result);
       } catch (error: any) {
         if (error.original.errors[0].includes('with key') || error.original.errors[0].includes('find page')) {
-          console.log('Section does not exist yet → creating new one');
           setSocialLinks(null);
           return;
         }
 
-        console.log('error', error);
+        console.error('error', error);
         toast.error('Failed to fetch partners');
       }
     }
@@ -66,7 +65,6 @@ function SocialLinksForm() {
   }, [dispatch]);
 
   async function handleSubmit(values: ISocialLinksValues) {
-    console.log('Submitted:', values);
 
     try {
       let result;

--- a/components/admin/NewsletterPage/NewsletterPage.tsx
+++ b/components/admin/NewsletterPage/NewsletterPage.tsx
@@ -22,17 +22,16 @@ function NewsletterPage() {
   const [submitError, setSubmitError] = useState('');
 
   async function handleSubmit(data: NewsletterRequestDTO) {
-    console.log('data', data);
 
     try {
       const result = await handleThunk(sendNewsletter, data, setSubmitError);
       toast.success(result);
     } catch (error: any) {
-      console.log('error', error);
+      console.error('error', error);
       toast.error('Failed to send newsletter');
     }
 
-    console.log('submitError', submitError);
+    console.error('submitError', submitError);
   }
 
 

--- a/components/admin/Pages/AboutUsForm.tsx
+++ b/components/admin/Pages/AboutUsForm.tsx
@@ -161,7 +161,7 @@ function AboutUsForm() {
         });
 
       } catch (error: any) {
-        console.log('error', error);
+        console.error('error', error);
         setAboutUsPage(null);
         toast.error('Failed to fetch About us page');
       }
@@ -179,7 +179,7 @@ function AboutUsForm() {
       try {
         await deleteFile(url);
       } catch (error: any) {
-        console.log('Failed to delete file', url, error);
+        console.error('Failed to delete file', url, error);
       }
     }
 
@@ -215,7 +215,7 @@ function AboutUsForm() {
 
         toast.success(`The translation was successfully created`);
       } catch (error) {
-        console.log('error translate', error);
+        console.error('error translate', error);
         toast.error(`Something go wrong with translation! ${error}`);
       }
     }

--- a/components/admin/Pages/HomeForm.tsx
+++ b/components/admin/Pages/HomeForm.tsx
@@ -144,7 +144,7 @@ function HomeForm() {
               editor = EditorState.createEmpty(decorator);
             }
           } catch (err: any) {
-            console.log('err', err);
+            console.error('err', err);
             editor = EditorState.createEmpty(decorator);
           }
 
@@ -162,12 +162,11 @@ function HomeForm() {
         });
       } catch (error: any) {
         if (error.original.errors[0].includes('with key') || error.original.errors[0].includes('find page')) {
-          console.log('Section does not exist yet → creating new one');
           setHomePage(null);
           return;
         }
 
-        console.log('error', error);
+        console.error('error', error);
         setHomePage(null);
         toast.error('Failed to fetch Home page');
       }
@@ -184,7 +183,7 @@ function HomeForm() {
       try {
         await deleteFile(url);
       } catch (error: any) {
-        console.log('Failed to delete file', url, error);
+        console.error('Failed to delete file', url, error);
       }
     }
 
@@ -224,7 +223,7 @@ function HomeForm() {
 
         toast.success(`The translation was successfully created`);
       } catch (error) {
-        console.log('error translate', error);
+        console.error('error translate', error);
         toast.error(`Something go wrong with translation! ${error}`);
       }
     }
@@ -336,7 +335,6 @@ function HomeForm() {
                               onClick={() => {
                                 const blockId = block.id;
                                 if (block.files) {
-                                  console.log('block.files', block.files);
                                   setDeletedFiles(prev => [...prev, ...block.files]);
                                 }
 

--- a/components/admin/ProgramsPage/ProgramContent/ProgramContent.tsx
+++ b/components/admin/ProgramsPage/ProgramContent/ProgramContent.tsx
@@ -266,7 +266,7 @@ function ProgramContent({ programId }: { programId: number }) {
           contentBlocks: mergedBlocks 
         });
       } catch (error) {
-        console.log('error', error);
+        console.error('error', error);
         router.push(`/admin/projects`);
         toast.error('Failed to fetch program');
       } finally {
@@ -282,10 +282,9 @@ function ProgramContent({ programId }: { programId: number }) {
   async function handleSubmit(values: UpdateArticleFormValues, { setSubmitting }: FormikHelpers<UpdateArticleFormValues>) {
     for (const url of deletedFiles) {
       try {
-        console.log('deleted url', url);
         await deleteFile(url);
       } catch (error: any) {
-        console.log('Failed to delete file', url, error);
+        console.error('Failed to delete file', url, error);
       }
     }
 
@@ -313,7 +312,6 @@ function ProgramContent({ programId }: { programId: number }) {
 
     const { translateDirection, ...rest } = values;
 
-    console.log('translateStatus', translateStatus);
 
     const preparedData = isEngDirection
       ? {
@@ -360,7 +358,7 @@ function ProgramContent({ programId }: { programId: number }) {
             toast.success(`The translation was successfully created`);
           } catch (error) {
             setSubmitStatus('idle');
-            console.log('error translate', error);
+            console.error('error translate', error);
             toast.error(`Something go wrong with translation! ${error}`);
           } finally {
             setSubmitStatus('idle');
@@ -541,7 +539,6 @@ function ProgramContent({ programId }: { programId: number }) {
                                         const blockIndex = values.contentBlocks.findIndex(b => b.id === block.id);
 
                                         if (block.files) {
-                                          console.log('block.files', block.files);
                                           setDeletedFiles(prev => [...prev, ...block.files]);
                                         }
 

--- a/components/admin/ProjectsPage/ProjectContent/ProjectContent.tsx
+++ b/components/admin/ProjectsPage/ProjectContent/ProjectContent.tsx
@@ -156,7 +156,7 @@ function ProjectContent({ projectId }: { projectId: number }) {
               ? EditorState.createWithContent(convertFromRaw(block.translatable_text_editorState), decorator)
               : EditorState.createEmpty(decorator);
           } catch (err: any) {
-            console.log('err', err);
+            console.error('err', err);
             editor = EditorState.createEmpty(decorator);
           }
 
@@ -173,7 +173,7 @@ function ProjectContent({ projectId }: { projectId: number }) {
           contentBlocks: mergedBlocks,
         });
       } catch (error) {
-        console.log('error', error);
+        console.error('error', error);
         router.push(`/admin/projects`);
         toast.error('Failed to fetch project');
       } finally {
@@ -192,7 +192,7 @@ function ProjectContent({ projectId }: { projectId: number }) {
         try {
           await deleteFile(url);
         } catch (error: any) {
-          console.log('Failed to delete file', url, error);
+          console.error('Failed to delete file', url, error);
         }
       }
 
@@ -246,7 +246,7 @@ function ProjectContent({ projectId }: { projectId: number }) {
               toast.success(`The translation was successfully created`);
             } catch (error) {
               setSubmitStatus('idle');
-              console.log('error translate', error);
+              console.error('error translate', error);
               toast.error(`Something go wrong with translation! ${error}`);
             } finally {
               setSubmitStatus('idle');

--- a/components/admin/UserActions/NewPasswordForm/NewPasswordForm.tsx
+++ b/components/admin/UserActions/NewPasswordForm/NewPasswordForm.tsx
@@ -23,7 +23,6 @@ const NewPasswordForm = ({ validationSchema }: IValidationSchema) => {
       }}
       validationSchema={validationSchema}
       onSubmit={(values: SetPasswordDto, { resetForm }) => {
-        console.log(values);
         resetForm();
       }}
     >

--- a/components/admin/UsersPage/UsersTable.tsx
+++ b/components/admin/UsersPage/UsersTable.tsx
@@ -65,7 +65,7 @@ function UsersTable({ users }: UsersProps) {
           });
       })
       .catch(err => {
-        console.log('errors', err.original.errors.toString());
+        console.error('errors', err.original.errors.toString());
         toast.error(
           err.original.errors.toString() || 'Failed to resend invitation',
         );

--- a/components/admin/helperComponents/ImageLoading/hook/useImageLoading.tsx
+++ b/components/admin/helperComponents/ImageLoading/hook/useImageLoading.tsx
@@ -42,7 +42,7 @@ function useImageLoading({ articleId, contentType, isAttach = false }: IImageLoa
 
           urls.push(response);
         } catch (error) {
-          console.log('error', error);
+          console.error('error', error);
           toast.error('Failed to upload files');
         }
       }

--- a/components/contacts/ContactForm.tsx
+++ b/components/contacts/ContactForm.tsx
@@ -139,7 +139,6 @@ const ContactForm = () => {
       try {
         const res = await handleSubmitContactForm(values);
 
-        console.log('res', res);
 
         setModalType('success');
         setModalTitle(t('modals.modal_contacts.succeed_title'));

--- a/components/home/HomePageClientSide.tsx
+++ b/components/home/HomePageClientSide.tsx
@@ -60,7 +60,7 @@ function HomePageClientSide({ initialHomePageData, initialPartnersData }: IHomeP
 
         setHomePage(buildHomePage(result, locale));
       } catch (error: any) {
-        console.log('error', error);
+        console.error('error', error);
         setHomePage(null);
         toast.error('Failed to fetch Home page');
       }
@@ -72,7 +72,7 @@ function HomePageClientSide({ initialHomePageData, initialPartnersData }: IHomeP
 
         setOurPartners(result);
       } catch (error: any) {
-        console.log('error', error);
+        console.error('error', error);
         toast.error('Failed to fetch partners');
         setOurPartners(null);
       }

--- a/components/home/PartnerForm.tsx
+++ b/components/home/PartnerForm.tsx
@@ -94,7 +94,7 @@ const PartnerForm = () => {
         resetForm();
       } catch (error: any) {
         setStatus(error?.original?.errors?.[0] ?? t('modals.modal_parthner.error_message'));
-        console.log('becomeParthner', error);
+        console.error('becomeParthner', error);
 
       }finally {
         setSubmitting(false);

--- a/components/layout/SubscribeForm.tsx
+++ b/components/layout/SubscribeForm.tsx
@@ -77,11 +77,10 @@ const SubscribeForm = () => {
         const result = await dispatch(createSubscribe(values.email)).unwrap();
         props.onOpenModal();
 
-        console.log('result', result);
 
         resetForm();
       } catch (error: any) {
-        console.log('createSubscribe', error );
+        console.error('createSubscribe', error );
         setStatus(error?.original?.errors?.[0] ?? t('modals.modal_subscribe.error_message'));
 
         

--- a/components/news/Article.tsx
+++ b/components/news/Article.tsx
@@ -68,7 +68,7 @@ export default function Article({ articleType, initialArticleData }: { articleTy
 
         setDopPrograms(result?.content);
       } catch (error) {
-        console.log('error', error);
+        console.error('error', error);
         toast.error('Failed to fetch project');
       }
     }

--- a/components/payment/PaymentForm.tsx
+++ b/components/payment/PaymentForm.tsx
@@ -53,7 +53,6 @@ const PaymentForm = () => {
   // const stripePromise = loadStripe(NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEYS);
 
   const handleStripeCheckout = async (paymentDetails: any) => {
-    console.log('paymentDetails', paymentDetails);
     const baseUrl =
       paymentDetails.paymentMethod === 'paypal'
         ? 'payments/paypal/checkout-session'
@@ -81,7 +80,7 @@ const PaymentForm = () => {
         setLoading(false);
       }
     } catch (error: any) {
-      console.log('error', error);
+      console.error('error', error);
       alert(error?.response?.data?.message);
       setLoading(false);
     }

--- a/components/program/ProgramPageClient.tsx
+++ b/components/program/ProgramPageClient.tsx
@@ -47,7 +47,7 @@ function ProgramPageClient({ initialProgramData }: { initialProgramData?: GetArt
         setLoading(false);
       } catch (error) {
         setLoading(false);
-        console.log('error', error);
+        console.error('error', error);
         toast.error('Failed to fetch project');
       }
     }
@@ -74,7 +74,7 @@ function ProgramPageClient({ initialProgramData }: { initialProgramData?: GetArt
 
         setDopPrograms(result?.content);
       } catch (error) {
-        console.log('error', error);
+        console.error('error', error);
         toast.error('Failed to fetch project');
       }
     }

--- a/components/socialButtons/SocialButtons.tsx
+++ b/components/socialButtons/SocialButtons.tsx
@@ -28,7 +28,7 @@ const SocialButtons = () => {
         setSocialLinks(response);
       } catch (error) {
         setSocialLinks(null);
-        console.log('fetchSocial error', error);
+        console.error('fetchSocial error', error);
       }
     }
 

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -12,6 +12,14 @@ const eslintConfig = [
       semi: ['error', 'always'],
       'prefer-arrow-callback': 'error',
       'prefer-template': 'error',
+      // console.error/warn are legitimate diagnostics and stay; log/info are
+      // debug leftovers. 66 of them had accumulated across 32 files (issue
+      // #457), including a plaintext password and donor PII. Note this rule
+      // cannot actually run yet -- npm run lint is broken under TypeScript 7
+      // (issue #454) -- so the enforceable guard today is the no-console-log
+      // job in _quality-gates.yml. This is here so the two agree the moment
+      // lint works again.
+      'no-console': ['error', { allow: ['error', 'warn'] }],
       'no-debugger':
         process.env.NODE_ENV === 'production' ? 'error' : 'warn',
     },

--- a/utils/hooks/useArticles.ts
+++ b/utils/hooks/useArticles.ts
@@ -56,7 +56,7 @@ export const useArticles = ({
 				setTotalPages(result?.totalPages);
       } catch (error) {
         setArticles([]);
-        console.log(error);
+        console.error(error);
       } finally {
         setLoading(false);
       }

--- a/utils/hooks/useUsers.ts
+++ b/utils/hooks/useUsers.ts
@@ -19,7 +19,6 @@ export function useUsers(isUserVerificated?: boolean) {
         [users],
     );
 
-    // console.log('usersList', usersList, usersList.map(u => typeof u.value));
 
     const currentUser = useAppSelector(state => state.authUser.user);
     const currentAuthor = users.find(user => user.name === currentUser?.name);

--- a/utils/http/http-request-service.ts
+++ b/utils/http/http-request-service.ts
@@ -9,7 +9,6 @@ import { toast } from 'react-toastify';
 import { getUserInfo, logOutAuth } from '@/store/auth/action';
 
 export const refreshAccessToken = async () => {
-  console.log('refreshAccessToken');
   try {
     await axiosInstance.post(ApiEndpoint.REFRESHTOKEN, {}, { withCredentials: true, headers: { 'Content-Type': 'application/x-www-form-urlencoded' } });
 
@@ -62,7 +61,6 @@ export async function request<T>(options: RequestOptions) {
       } as any;
     }
 
-    // console.log('response', response);
     return response.data;
   } catch (error: unknown) {
     const err = error as AxiosError;


### PR DESCRIPTION
Closes #457.

All 66 calls across 32 files are gone: **39 carried an error and became `console.error`** (keeping the diagnostic, moving it to the right channel), the other **27 were debug leftovers and were deleted**. `console.error`/`console.warn` are untouched.

## Two of these were not noise

The issue said the payment and contact-form ones were "worth reading individually." That was right — two leaked real data to the browser console on ordinary user actions:

| Where | What it logged |
|---|---|
| `NewPasswordForm.tsx` | **`values` on submit — the user's new password and confirmation, in plaintext**, on the admin password-reset page |
| `PaymentForm.tsx` | **The entire donation form on every checkout** — donor name, email, amount, purpose, comment |

A third, in `http-request-service.ts`, fired on **every token refresh**, so it repeated continuously for any logged-in admin.

## The guard is the point

The issue notes this "will keep accumulating until [lint] is fixed" — `npm run lint` cannot run at all under TypeScript 7 (#454). A dead `.eslintrc.json`, whose `no-console` rule only *looked* active, is precisely why 66 accumulated in the first place. Removing the calls without enforcement just resets the counter.

So both halves are here:

- **`no-console-log` job in `_quality-gates.yml`** — a grep that works *today* and fails the build, mirroring the existing `casing-guard`. Verified in both directions: passes on the clean tree, and catches a deliberately planted `console.log`.
- **`no-console` rule in `eslint.config.mjs`** (allowing `error`/`warn`) so the two agree the moment lint runs again.

`scripts/` and `e2e/` are excluded — Node CLI tools and test harnesses where writing to stdout is the entire point.

## Verification

- `tsc --noEmit` → **0 errors**
- **109 unit tests** pass
- clean `npm run build` → exit 0
- guard verified to pass clean **and** to fail on a planted call

## Separate finding, not fixed here

`NewPasswordForm`'s `onSubmit` did nothing *except* the `console.log` and a `resetForm()` — **it never calls any API**. So `/admin/newPassword` is a non-functional duplicate of the working `/admin/setPassword` flow (which has a real `handleSetPassword`). Removing the log doesn't change that: the page still silently does nothing.

That needs its own decision — delete the dead route, or wire it up — and wiring an auth flow unreviewed is not something to slip into a logging cleanup. Worth its own issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)