### PR TITLE
fix: enforce a coverage floor, and fix the number it measures (#462)

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -51,4 +51,12 @@ These are draft-js/dropzone-heavy forms with a lot of orchestration logic packed
 
 ## Coverage philosophy
 
-No hard coverage percentage gate yet — there's no baseline to set a meaningful floor against. `test:coverage` runs in CI and uploads the `coverage/` directory as a build artifact on every run, so trend is visible without blocking anything. Revisit introducing a numeric floor (via `vitest.config.ts`'s `coverage.thresholds`) after a few months of real usage.
+**A coverage floor is now enforced** (issue #462), and adding it corrected a much bigger problem than the missing gate.
+
+Coverage previously reported **~55–61%**, including on the public status page. That number was measured only over files a test happened to import — `vitest.config.ts` had no `coverage.include`, so v8 reported on loaded files only. With 371 source files in the repo, most were simply absent from the denominator. It also moved the wrong way: deleting tests *raised* the figure, because the survivors were the well-covered ones, and adding a large untested surface did not move it at all.
+
+Setting `coverage.include` to the source tree gives the honest number: **7.61% statements, 6.4% branches, 4.88% functions, 7.84% lines** (336 of 4414 statements), measured 2026-07-31. Nothing got worse — the denominator got real. Expect the status-page figure to drop accordingly.
+
+`coverage.thresholds` is set just below each measured value, so coverage cannot fall without failing the build. Raise them as coverage improves; never lower them to make a build pass.
+
+`--passWithNoTests` was also removed from the `test` and `test:coverage` scripts. It dated from before any tests existed and meant a repo with zero tests exited 0. Verified end to end: with all 13 unit-test files removed the build now fails with `Coverage for lines (0%) does not meet global threshold (7%)`, where previously it passed cleanly.

--- a/package.json
+++ b/package.json
@@ -11,9 +11,9 @@
     "start": "next start",
     "lint": "eslint .",
     "typecheck": "tsc --noEmit",
-    "test": "vitest run --passWithNoTests",
+    "test": "vitest run",
     "test:watch": "vitest",
-    "test:coverage": "vitest run --coverage --passWithNoTests",
+    "test:coverage": "vitest run --coverage",
     "test:e2e": "playwright test",
     "format": "prettier --write .",
     "format:check": "prettier --check ."

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -26,6 +26,52 @@ export default defineConfig({
       provider: 'v8',
       reporter: ['text', 'lcov', 'html', 'json-summary'],
       reportsDirectory: './coverage',
+      // Without an explicit `include`, v8 only reports on files a test actually
+      // imported. That made the headline number meaningless: it read 60.91%
+      // over 614 statements, but the repo has 371 source files and most were
+      // simply absent from the denominator. Worse, it moved the wrong way —
+      // deleting tests *raised* the percentage, because the remaining files
+      // were the well-covered ones, and adding a large untested surface did not
+      // move it at all. Enumerating the source tree here is what makes the
+      // ratchet below mean something (issue #462).
+      include: [
+        'app/**/*.{ts,tsx}',
+        'components/**/*.{ts,tsx}',
+        'utils/**/*.{ts,tsx}',
+        'store/**/*.{ts,tsx}',
+        'stores/**/*.{ts,tsx}',
+        'i18n/**/*.{ts,tsx}',
+        'middleware.ts',
+      ],
+      exclude: [
+        '**/*.test.{ts,tsx}',
+        '**/*.d.ts',
+        // Barrel files that only re-export, and type-only modules: no runtime
+        // behaviour to cover, so counting them just dilutes the number.
+        '**/type/**',
+        '**/types/**',
+        '**/enums/**',
+        '**/index.ts',
+      ],
+      // A ratchet, not a target (issue #462). Measured 2026-07-31 across the
+      // whole source tree: 7.61% statements, 6.4% branches, 4.88% functions,
+      // 7.84% lines (336/4414 statements). Each floor sits just below that, so
+      // coverage cannot fall without failing the build.
+      //
+      // The number is low because it is finally honest. The ~55-61% reported
+      // before — and published to the status page — was measured only over
+      // files a test happened to import, which is why adding the `include`
+      // above dropped it roughly eightfold. Nothing got worse; the denominator
+      // got real.
+      //
+      // Raise these as coverage improves. Never lower them to make a build
+      // pass: that is precisely the failure mode this exists to prevent.
+      thresholds: {
+        statements: 7,
+        branches: 6,
+        functions: 4,
+        lines: 7,
+      },
     },
     reporters: ['default', 'json'],
     outputFile: { json: '.status-data/vitest-results.json' },


### PR DESCRIPTION
Closes #462.

Adding the threshold the issue asked for exposed a bigger problem: **the percentage being gated was wrong by roughly eightfold.**

## The reported coverage was never a coverage figure

`vitest.config.ts` had no `coverage.include`, so v8 reported only on files a test happened to **import**. The repo has 371 source files; most were absent from the denominator entirely.

That made it move the wrong way in both directions the issue cares about:

- **Deleting tests *raised* the number** — the survivors were the well-covered files.
- **Adding a large untested surface didn't move it at all** — new files simply weren't counted.

So the **~55–61%** previously reported, and published on the public status page, was measuring "how well covered are the files we already test", not this codebase.

With `include` set to the source tree, the honest number is:

| | Before (loaded files only) | After (whole source tree) |
|---|---|---|
| Statements | 60.91% (374/614) | **7.61%** (336/4414) |
| Branches | 66.37% | **6.4%** |
| Functions | 43.03% | **4.88%** |
| Lines | 61.02% | **7.84%** |

**Nothing got worse — the denominator got real.** Expect the status-page figure to drop accordingly; that is the fix working, not a regression.

## What's enforced

`thresholds` sit just below each measured value — a ratchet, not a target, same pattern as the typecheck gate. Type-only modules, barrels and enums are excluded: no runtime behaviour to cover, so counting them would only dilute the figure.

**`--passWithNoTests` is also gone** from `test` and `test:coverage`. It dated from before any tests existed and meant a repo with zero tests exited 0.

## Verified in three directions, not assumed

1. **Passes at real coverage** — exit 0, 109 tests.
2. **A breach actually fails** — raising the statements floor to 25% gives exit 1 and `ERROR: Coverage for statements (7.61%) does not meet global threshold (25%)`.
3. **The issue's headline scenario now fails** — with all 13 unit-test files removed the build exits 1 with `Coverage for lines (0%) does not meet global threshold (7%)`. Before this change, that passed cleanly.

Test files were restored and `git status` confirmed no deletions pending.

## Reviewer note

The low number is uncomfortable but it is the real one, and it can now only go up. I'd rather gate an honest 7.6% than a comfortable 61% that was structurally incapable of detecting the regressions it was supposed to catch.

`docs/testing.md` is updated to explain the drop, so the status-page change doesn't read as something breaking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)