### PR TITLE
fix: stop the release script and prettier fighting over Chart.yaml

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -8,6 +8,15 @@ helm/**/templates/
 # conflict on the next release commit, for no benefit.
 CHANGELOG.md
 
+# Rewritten by scripts/release/bump-chart-version.sh on every release, which
+# writes `appVersion: "X.Y.Z"` with double quotes while .prettierrc sets
+# singleQuote. Left in, the two oscillate: prettier rewrites it to single
+# quotes, the next release rewrites it back, and format-check fails on the
+# following PR. The script's own comment warns that a reformatted Chart.yaml
+# can silently break the version bump — so formatting it is the hazard it is
+# defending against, not an improvement.
+helm/frontend-chart/Chart.yaml
+
 # npm owns this file's shape.
 package-lock.json
 


### PR DESCRIPTION
The `format-check` gate added in #484 **fails on the current promotion PR ([#486](https://github.com/NewWave4Org/NewWave4.org-frontend-new/pull/486)), and would fail after every release.**

Caught by the gate itself — which is the gate doing its job, but it needs fixing before the promotion can merge.

## The loop

`scripts/release/bump-chart-version.sh` writes:

```yaml
appVersion: "1.4.0-dev.15"     # double quotes
```

while `.prettierrc` sets `singleQuote: true`, so Prettier wants:

```yaml
appVersion: '1.4.0-dev.15'
```

The two oscillate forever: Prettier rewrites it to single quotes, the next release rewrites it back to double, and `format-check` fails on the following PR. It passed locally when #484 was cut only because the offending bump hadn't landed yet.

## Why excluded rather than reconciled

Making the script emit single quotes would work today, but it couples the release script to the Prettier config permanently — change either and the breakage surfaces at *release* time, which is the worst place to find it.

More decisively, the script's own comment warns:

> `sed -i` exits 0 even when its pattern matched zero lines (e.g. if Chart.yaml's `version:`/`appVersion:` keys ever get renamed, reordered, or **reformatted**) — silently leaving the chart on its old version while semantic-release still tags/publishes the new one everywhere else.

Having Prettier rewrite that file is exactly the hazard the script is defending against. Excluding it removes the class of problem instead of balancing two tools against each other.

Same reasoning as `CHANGELOG.md`, already excluded for being release-automation-written.

## Verification

`prettier --check .` is clean across the tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)