### PR TITLE
fix: unblock Dependabot PRs, which could never pass a required check

### DIFF
--- a/.env.ci
+++ b/.env.ci
@@ -1,6 +1,13 @@
-# Non-secret placeholder values used only by the `build` quality-gate job in CI
-# (.github/workflows/_quality-gates.yml) to verify `next build` compiles successfully.
-# This is NOT used for the docker-smoke job or any deploy — those use real secrets.
+# Non-secret placeholder values, used by the docker-smoke job in
+# .github/workflows/_quality-gates.yml when no repo secrets are available —
+# i.e. on Dependabot and fork PRs, which GitHub deliberately runs without them.
+# Without this the build fails on utils/env.ts's required-variable check and
+# every dependency update is unmergeable.
+#
+# Never used when real secrets ARE present, and never for a deploy: docker-smoke
+# builds with `push: false`, so nothing built from these values is published.
+# The API host is intentionally unreachable (.invalid is reserved by RFC 2606),
+# so anything that quietly depended on a real backend fails loudly here.
 NEXT_PUBLIC_PAYPAL_CLIENT_ID=ci-placeholder
 NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEYS=ci-placeholder
 NEXT_PUBLIC_STRIPE_WEBHOOK_URL=https://ci.invalid/webhook

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,18 @@ updates:
     target-branch: 'development'
     schedule:
       interval: 'weekly'
+    groups:
+      # react and react-dom must move together — they are a matched pair, and
+      # React throws on a version mismatch. Dependabot bumped react to 19.2.8
+      # while react-dom stayed on 19.2.0 (PR #492), which failed three React
+      # Testing Library suites at load time. Grouping them means one PR that
+      # updates both, instead of one that cannot pass.
+      react:
+        patterns:
+          - 'react'
+          - 'react-dom'
+          - '@types/react'
+          - '@types/react-dom'
   - package-ecosystem: 'docker'
     directory: '/'
     target-branch: 'development'

--- a/.github/workflows/_quality-gates.yml
+++ b/.github/workflows/_quality-gates.yml
@@ -153,6 +153,13 @@ jobs:
     name: docker-smoke
     needs: casing-guard
     runs-on: ubuntu-latest
+    env:
+      # Dependabot and fork PRs run without access to repo secrets. generate-env
+      # then writes empty values, utils/env.ts fails the build on three missing
+      # required vars, and docker-smoke fails — a *required* status check, so
+      # every dependency update including security ones was permanently
+      # unmergeable. This flag lets the job fall back to committed placeholders.
+      HAS_SECRETS: ${{ secrets.NEXT_PUBLIC_NEWWAVE_API_URL != '' }}
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v7
@@ -161,6 +168,7 @@ jobs:
         uses: ./.github/actions/set-org-lowercase
 
       - name: Generate .env file
+        if: env.HAS_SECRETS == 'true'
         uses: ./.github/actions/generate-env
         with:
           paypal_client_id: ${{ secrets.NEXT_PUBLIC_PAYPAL_CLIENT_ID }}
@@ -168,6 +176,18 @@ jobs:
           stripe_webhook_url: ${{ secrets.NEXT_PUBLIC_STRIPE_WEBHOOK_URL }}
           newwave_api_url: ${{ secrets.NEXT_PUBLIC_NEWWAVE_API_URL }}
           site_url: ${{ secrets.NEXT_PUBLIC_SITE_URL }}
+
+      # `.env.ci` is committed, non-secret, and points at https://ci.invalid.
+      # Verified locally that a real image built from it starts and serves the
+      # homepage, so both smoke assertions still mean something: this checks the
+      # app compiles and boots, which is exactly what a dependency bump needs.
+      # It cannot mask a missing production secret, because this job only builds
+      # (`push: false`) — nothing published or deployed comes from here.
+      - name: Use committed CI placeholders (no secrets on Dependabot/fork PRs)
+        if: env.HAS_SECRETS != 'true'
+        run: |
+          echo "::notice::No repo secrets available (Dependabot or fork PR) — building with .env.ci placeholders."
+          cp .env.ci .env
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4


### PR DESCRIPTION
All five open Dependabot PRs (#488–#492) fail `docker-smoke`. **No dependency update could ever have merged — including security updates** — because `docker-smoke` is a required status check.

## Why

GitHub deliberately runs Dependabot and fork PRs **without repo secrets**. `generate-env` then writes empty values, and `utils/env.ts` fails the build:

```
Error: Invalid environment — 3 problems found:
  - NEXT_PUBLIC_PAYPAL_CLIENT_ID: required but missing or empty
  - NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEYS: required but missing or empty
  - NEXT_PUBLIC_NEWWAVE_API_URL: required but missing or empty
```

This is a collision between two things that are each individually correct: fail-fast env validation, and Dependabot's secret isolation.

## The fix

Fall back to **`.env.ci`** when no secrets are present. That file already existed with exactly the right placeholders and was referenced by **no workflow** — its own header described it as serving a `build` job that has since been removed. Header corrected.

The fallback is narrow:

- **Only triggers when secrets are genuinely absent** (`HAS_SECRETS` job-level flag).
- **Cannot mask a missing production secret** — `docker-smoke` builds with `push: false`, so nothing published or deployed is produced from these values.
- The API host is `https://ci.invalid` (RFC 2606 reserved, unresolvable), so anything quietly depending on a real backend fails loudly rather than passing by accident.

## Verified, not assumed

I built a real image from `.env.ci`, ran it, and checked the two assertions `docker-smoke` actually makes:

```
homepage: <!DOCTYPE html> present ✓
/api/version: {"version":"0.0.0-dev","commit":"unknown",...} ✓
```

The app boots without a reachable backend, so the check still means *"this compiles and starts"* — which is what a dependency bump needs it to mean. Had it not booted, the fallback would have been worthless and I'd have needed a different approach.

## A second, separate failure in #492

[#492](https://github.com/NewWave4Org/NewWave4.org-frontend-new/pull/492) also fails three React Testing Library suites **at load time**. Dependabot bumped `react` to `19.2.8` while leaving `react-dom` on `19.2.0` — they are a matched pair, and React throws on a mismatch.

Added a `dependabot.yml` group so `react`, `react-dom` and their `@types` always move in a single PR.

**#492 itself will still fail** after this merges: it needs `react-dom` bumped too, or should be closed and superseded by the grouped update. The other four (#488–#491) should go green.

## Verification

- `prettier --check` clean, `tsc --noEmit` 0 errors
- both changed YAML files parse

🤖 Generated with [Claude Code](https://claude.com/claude-code)