### PR TITLE
fix: skip docker-pr-publish for Dependabot, the last red check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,17 @@ jobs:
   docker-pr-publish:
     name: docker-pr-publish
     needs: quality-gates
-    if: github.event_name == 'pull_request' && github.base_ref == 'development'
+    # Skipped for Dependabot, which GitHub runs without repo secrets. This job
+    # exists to give a reviewer a pullable image; built from placeholder env it
+    # would point at https://ci.invalid and be actively misleading to anyone who
+    # ran it. docker-smoke already proves a dependency bump still builds and
+    # boots (it falls back to .env.ci deliberately — see _quality-gates.yml),
+    # and that is the check that matters here. Dependabot's token is also
+    # read-only for packages, so the push would fail even if the build did not.
+    if: >-
+      github.event_name == 'pull_request'
+      && github.base_ref == 'development'
+      && github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
     permissions:
       packages: write


### PR DESCRIPTION
Follow-up to #493. That fixed `docker-smoke` for Dependabot PRs — **it now passes** — but the PRs stay red on `docker-pr-publish`.

Same root cause, different job: `ci.yml` has its **own** `generate-env` step that #493 didn't touch, so `npm run build` still fails on the three missing required env vars.

## Skipped rather than given the same fallback

`docker-pr-publish` exists to give a reviewer a pullable image. Built from placeholder env it would point at `https://ci.invalid` and be **actively misleading** to anyone who pulled and ran it. Dependabot's token is also read-only for packages, so the push would fail even if the build succeeded.

Nothing is lost:

- `docker-smoke` already builds the same Dockerfile **and boots the container** — the check that actually matters for a dependency bump.
- `docker-smoke` is a **required** check; `docker-pr-publish` is not.

## Evidence from the rebased #488

After #493 landed, the new run shows:

```
quality-gates / casing-guard:    success
quality-gates / lint:            success
quality-gates / typecheck:       success
quality-gates / format-check:    success
quality-gates / unit-test:       success
quality-gates / no-console-log:  success
quality-gates / docker-smoke:    success   <- was failing before #493
docker-pr-publish:               failure   <- this PR
```

So this is the last red check on #488–#491.

🤖 Generated with [Claude Code](https://claude.com/claude-code)