### PR TITLE
ci: skip build gates for documentation-only pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,57 @@ on:
   workflow_dispatch:
 
 jobs:
+  # Decides whether this change can affect the build at all. Deliberately NOT
+  # done with `paths-ignore` on the trigger above: three of this workflow's
+  # checks are *required* by branch protection, and a workflow skipped by path
+  # filtering never reports them at all — the PR then waits on a check that can
+  # never arrive and is unmergeable forever. Skipping the job instead still
+  # produces a check run (conclusion: skipped), which satisfies the requirement.
+  #
+  # Fails safe: anything that is not clearly documentation counts as code, and
+  # non-pull_request events always run the full gates.
+  changes:
+    name: changes
+    runs-on: ubuntu-latest
+    outputs:
+      code: ${{ steps.filter.outputs.code }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Detect whether anything outside docs changed
+        id: filter
+        env:
+          EVENT: ${{ github.event_name }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -euo pipefail
+          if [ "$EVENT" != "pull_request" ]; then
+            echo "Not a pull_request event — running full gates."
+            echo "code=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          CHANGED=$(git diff --name-only "$BASE_SHA" "$HEAD_SHA")
+          echo "Changed files:"
+          echo "$CHANGED" | sed 's/^/  /'
+
+          # Documentation-only means: docs/, or a top-level *.md. Everything
+          # else — including .github/, package.json and any source file — is
+          # code. Workflow changes must always be exercised by the real gates.
+          if printf '%s\n' "$CHANGED" | grep -qvE '^(docs/|[^/]+\.md$)'; then
+            echo "code=true" >> "$GITHUB_OUTPUT"
+            echo "Non-documentation changes present — running full gates."
+          else
+            echo "code=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::Documentation-only change — skipping build gates."
+          fi
+
   quality-gates:
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
     uses: ./.github/workflows/_quality-gates.yml
     secrets: inherit
 


### PR DESCRIPTION
A docs-only change currently runs the whole pipeline — casing-guard, lint, typecheck, unit-test, format-check, no-console-log, **docker-smoke** and a docker image publish. `docker-smoke` alone builds a production image and boots a container. None of that can be affected by editing a markdown file.

## Why not `paths-ignore`

This is the obvious fix and it would **break the repo**. Three of this workflow's checks are required by branch protection:

```
quality-gates / casing-guard
quality-gates / unit-test
quality-gates / docker-smoke
```

A workflow skipped by path filtering **never reports its checks at all**, so a required check sits pending forever and the PR becomes permanently unmergeable. This repo has already lost time to the "PR with checks that can never arrive" failure mode (see the promotion-PR entries in `known-issues.md`), so it's worth not reintroducing it.

Skipping the **job** instead still produces a check run with a `skipped` conclusion, which is the documented way to satisfy a required check without doing the work.

## The filter fails safe

Only `docs/` and top-level `*.md` count as documentation. Everything else — source, `package.json`, `helm/`, and `.github/` itself — counts as code. Verified against realistic changesets before committing:

| Changed | Result |
| --- | --- |
| `docs/*.md` only | **skip** |
| top-level `README.md` only | **skip** |
| docs + a source file | run |
| a workflow file | run |
| `package.json` | run |
| `helm/frontend-chart/values.yaml` | run |

Workflow changes always run the gates, so **this change cannot switch off its own testing** — including on this PR, which touches `.github/` and therefore exercises the full pipeline.

Non-`pull_request` events (pushes, `workflow_dispatch`) always run everything.

## What still needs empirical confirmation

The workflow file alone cannot establish whether **GitHub treats a `skipped` required check as satisfied**. I've written it the way that is supposed to work, but I'd rather verify than assert.

**#503 is documentation-only and is the test case.** After this merges I'll re-trigger it and confirm it reports skipped checks *and* becomes `MERGEABLE`. If it doesn't, this needs a different approach — not a loosening of the required-checks list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)