### PR TITLE
ci: keep docs-only gates reporting instead of skipping them

### DIFF
--- a/.github/workflows/_quality-gates.yml
+++ b/.github/workflows/_quality-gates.yml
@@ -4,6 +4,17 @@ name: Quality Gates
 # Called by ci.yml (feature/fix branches, PRs) and release.yml (main/development pushes).
 on:
   workflow_call:
+    inputs:
+      run_full:
+        description: >-
+          When false, every job below still runs and reports its check, but does
+          no work. Used for documentation-only pull requests (see ci.yml).
+          The jobs must not be skipped outright: three of their check names are
+          required by branch protection, and a job that never exists never
+          reports, leaving the PR blocked on a check that can never arrive.
+        type: boolean
+        required: false
+        default: true
 
 jobs:
   casing-guard:
@@ -11,9 +22,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
+        if: inputs.run_full
         uses: actions/checkout@v7
 
       - name: Guard mis-cased import paths
+        if: inputs.run_full
         run: |
           set -e
           bad=0
@@ -38,6 +51,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
+        if: inputs.run_full
         uses: actions/checkout@v7
 
       # eslint.config.mjs carries a matching no-console rule, but `npm run lint`
@@ -52,6 +66,7 @@ jobs:
       # scripts/ and e2e/ are excluded -- Node CLI tools and test harnesses
       # where writing to stdout is the entire point.
       - name: Guard against console.log/console.info in shipped code
+        if: inputs.run_full
         run: |
           set -e
           if grep -RInE "console\.(log|info)\s*\(" \
@@ -68,10 +83,12 @@ jobs:
     steps:
       - uses: actions/checkout@v7
       - uses: actions/setup-node@v7
+        if: inputs.run_full
         with:
           node-version-file: '.nvmrc'
           cache: 'npm'
       - run: npm ci
+        if: inputs.run_full
       # `format:check` existed but was wired into no workflow, so 320 files had
       # drifted out of style with nothing to catch it (issue #455). Blocking
       # from the start: the tree was formatted in the same PR that added this,
@@ -81,6 +98,7 @@ jobs:
       # templating is not valid YAML and Prettier throws a hard SyntaxError on
       # it, which would make this job unpassable.
       - name: Check formatting
+        if: inputs.run_full
         run: npm run format:check
 
   typecheck:
@@ -89,14 +107,17 @@ jobs:
     steps:
       - uses: actions/checkout@v7
       - uses: actions/setup-node@v7
+        if: inputs.run_full
         with:
           node-version-file: '.nvmrc'
           cache: 'npm'
       - run: npm ci
+        if: inputs.run_full
       # Blocking since 2026-07-31: the 36-error backlog that forced
       # continue-on-error is paid off (issue #453) and the tree is clean, so
       # this is now the ratchet — any new type error fails the build.
       - name: Type check
+        if: inputs.run_full
         run: npx tsc --noEmit
 
   lint:
@@ -105,14 +126,17 @@ jobs:
     steps:
       - uses: actions/checkout@v7
       - uses: actions/setup-node@v7
+        if: inputs.run_full
         with:
           node-version-file: '.nvmrc'
           cache: 'npm'
       - run: npm ci
+        if: inputs.run_full
       # Non-blocking: typescript@7.0.2 is incompatible with eslint-config-next's
       # bundled typescript-eslint (upstream blocker, see CLAUDE.md and
       # docs/decisions/0003-lint-non-blocking-pending-ts7-support.md).
       - name: Lint (non-blocking, see docs/known-issues.md)
+        if: inputs.run_full
         continue-on-error: true
         run: npx eslint .
 
@@ -122,13 +146,16 @@ jobs:
     steps:
       - uses: actions/checkout@v7
       - uses: actions/setup-node@v7
+        if: inputs.run_full
         with:
           node-version-file: '.nvmrc'
           cache: 'npm'
       - run: npm ci
+        if: inputs.run_full
       - run: npm run test:coverage
+        if: inputs.run_full
       - name: Upload coverage
-        if: always()
+        if: always() && inputs.run_full
         uses: actions/upload-artifact@v7
         with:
           name: coverage
@@ -162,13 +189,15 @@ jobs:
       HAS_SECRETS: ${{ secrets.NEXT_PUBLIC_NEWWAVE_API_URL != '' }}
     steps:
       - name: Checkout Repository
+        if: inputs.run_full
         uses: actions/checkout@v7
 
       - name: Set Org Lowercase
+        if: inputs.run_full
         uses: ./.github/actions/set-org-lowercase
 
       - name: Generate .env file
-        if: env.HAS_SECRETS == 'true'
+        if: env.HAS_SECRETS == 'true' && inputs.run_full
         uses: ./.github/actions/generate-env
         with:
           paypal_client_id: ${{ secrets.NEXT_PUBLIC_PAYPAL_CLIENT_ID }}
@@ -184,15 +213,17 @@ jobs:
       # It cannot mask a missing production secret, because this job only builds
       # (`push: false`) — nothing published or deployed comes from here.
       - name: Use committed CI placeholders (no secrets on Dependabot/fork PRs)
-        if: env.HAS_SECRETS != 'true'
+        if: env.HAS_SECRETS != 'true' && inputs.run_full
         run: |
           echo "::notice::No repo secrets available (Dependabot or fork PR) — building with .env.ci placeholders."
           cp .env.ci .env
 
       - name: Set up Docker Buildx
+        if: inputs.run_full
         uses: docker/setup-buildx-action@v4
 
       - name: Docker build for testing
+        if: inputs.run_full
         uses: docker/build-push-action@v7
         with:
           context: .
@@ -209,6 +240,7 @@ jobs:
             IMAGE_TAG=${{ github.sha }}
 
       - name: Docker image smoke test
+        if: inputs.run_full
         env:
           EXPECTED_COMMIT: ${{ github.sha }}
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,10 +66,16 @@ jobs:
             echo "::notice::Documentation-only change — skipping build gates."
           fi
 
+  # NOT `if: ... == 'true'`. Skipping this call outright means its child jobs
+  # never exist, so the required contexts `quality-gates / casing-guard`,
+  # `/ unit-test` and `/ docker-smoke` never report and the PR is blocked on
+  # checks that can never arrive — verified the hard way on PR #503. Passing a
+  # flag instead keeps every job running and reporting, doing no work.
   quality-gates:
     needs: changes
-    if: needs.changes.outputs.code == 'true'
     uses: ./.github/workflows/_quality-gates.yml
+    with:
+      run_full: ${{ needs.changes.outputs.code == 'true' }}
     secrets: inherit
 
   # Ephemeral, traceable image for manual reviewer pulls on PRs into development.


### PR DESCRIPTION
Fixes the approach in #504, which **does not work** — verified on PR #503 rather than assumed.

## What went wrong

#504 skipped the `quality-gates` workflow call for documentation-only PRs. Testing it on a real docs-only PR showed:

| Required context | Actually reported |
| --- | --- |
| `quality-gates / casing-guard` | ❌ never reported |
| `quality-gates / unit-test` | ❌ never reported |
| `quality-gates / docker-smoke` | ❌ never reported |
| `lint-pr-title` | ✅ success |

Skipping a reusable-workflow **call** means its child jobs never exist, so those three required names never report at all. The PR then waits forever on checks that cannot arrive — **exactly the failure mode #504 set out to avoid**, reintroduced by the fix itself.

The distinction I relied on — "a skipped job satisfies a required check" — only holds when the *named* check itself reports as skipped. A child of a workflow that never ran reports nothing.

## The corrected approach

**Never skip a job whose name is required.** `_quality-gates.yml` now takes a `run_full` input; `ci.yml` passes the docs-only result into it instead of gating the call.

Every job still runs, still reports, and does no work — no `npm ci`, no docker build, no image publish. Only the checkout remains, so the saving is nearly all of the wall clock.

## A bug caught while writing it

The first pass appended `if: inputs.run_full` to every step, including the coverage upload that already had `if: always()`. That produced **two `if:` keys on one step** — which YAML accepts silently, keeping the last. It would have quietly disabled the `always()` semantics, so coverage would stop uploading on failed runs.

Conditions are now combined (`always() && inputs.run_full`), and the file is checked for duplicate keys.

## Verification so far

- both workflow files parse
- no step has a duplicate `if:` key
- `prettier --check` clean
- this PR touches `.github/`, so it runs the **full** gates — proving the `run_full: true` path

The docs-only path gets verified after merge, by re-running #503 and confirming all three required contexts report *and* it stays mergeable. If they still don't report, this needs a different approach again — not a change to the required-checks list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)