### PR TITLE
ci: skip the PR image build for documentation-only changes too

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,7 +82,7 @@ jobs:
   # Never a real semver, never auto-deployed anywhere.
   docker-pr-publish:
     name: docker-pr-publish
-    needs: quality-gates
+    needs: [changes, quality-gates]
     # Skipped for Dependabot, which GitHub runs without repo secrets. This job
     # exists to give a reviewer a pullable image; built from placeholder env it
     # would point at https://ci.invalid and be actively misleading to anyone who
@@ -94,6 +94,7 @@ jobs:
       github.event_name == 'pull_request'
       && github.base_ref == 'development'
       && github.actor != 'dependabot[bot]'
+      && needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
     permissions:
       packages: write


### PR DESCRIPTION
Follow-up to #505, based on measuring the result rather than assuming it was done.

## The measurement

The docs-only run after #505 came to **114 job-seconds**:

| Job | Docs-only | Was |
| --- | --- | --- |
| `quality-gates / docker-smoke` | **6s** | ~103s |
| `quality-gates / unit-test` | **8s** | ~48s |
| `quality-gates / typecheck` | 4s | ~35s |
| others | 2–8s each | 30–40s each |
| **`docker-pr-publish`** | **68s** | 68s — *unchanged* |

The gates were down to near-nothing, but the image build was still running in full — it lives in `ci.yml` rather than the reusable workflow, so #505 never touched it. It accounted for **60% of the remaining time**.

## The fix

Skipped **outright**, not emptied. Unlike the `quality-gates` jobs, `docker-pr-publish` is **not** a required check, so a job that doesn't exist can't block a PR. That's the same distinction #505 turned on, applied in the opposite direction — and it's why the two need different treatment.

Building a reviewer image for a markdown edit was never useful: there's nothing in it to pull and run that differs from the previous image.

## Verification

- `ci.yml` parses; `needs: [changes, quality-gates]`, condition includes `needs.changes.outputs.code == 'true'`
- `prettier --check` clean
- this PR touches `.github/`, so it runs the full pipeline — exercising the `code=true` path

🤖 Generated with [Claude Code](https://claude.com/claude-code)